### PR TITLE
Preventing dragging circle in the line chart to excess the canvas boundaries

### DIFF
--- a/app/charts/src/main/java/com/hd/charts/internal/linechart/LineChart.kt
+++ b/app/charts/src/main/java/com/hd/charts/internal/linechart/LineChart.kt
@@ -154,9 +154,13 @@ private fun DrawScope.drawChartPath(
             scaledValues = values,
             size = size
         )
+        val draggingCircleOffset = Offset(
+            nearestPoint.x.coerceIn(0f, canvasWidth),
+            nearestPoint.y.coerceIn(0f, canvasHeight)
+        )
 
         drawCircle(
-            center = nearestPoint,
+            center = draggingCircleOffset,
             radius = 15f,
             color = style.pointColor
         )


### PR DESCRIPTION
Before:

https://github.com/dautovicharis/Charts/assets/94565457/dd4fb301-8e75-4e81-91eb-804376025112

After:

https://github.com/dautovicharis/Charts/assets/94565457/78705e55-8e0f-4a6b-ac52-dc0593d49ca8

