### PR TITLE
Fix the title when drag ends.

### DIFF
--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/BarStackedChartView.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/BarStackedChartView.kt
@@ -73,7 +73,7 @@ private fun ChartContent(dataSet: MultiChartDataSet, style: StackedBarChartStyle
             colors = colors
         ) { selectedIndex ->
             title = when (selectedIndex) {
-                NO_SELECTION -> title
+                NO_SELECTION -> dataSet.data.title
                 else -> {
                     dataSet.data.items[selectedIndex].label
                 }


### PR DESCRIPTION
In current code, the last focussed bar label becomes the title when drag is finished.

Redo the PR#134 on develop branch. 