### PR TITLE
Fix the height of bar charts when a bar is focussed.

### DIFF
--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barchart/BarChart.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barchart/BarChart.kt
@@ -101,20 +101,19 @@ private fun DrawScope.drawBars(
         val spacing = style.space.toPx()
         val barWidth = (size.width - spacing * (dataSize - 1)) / dataSize
 
-        val finalBarHeight = size.height * (abs(value) / (maxValue - minValue))
+        val selectedBarScale = if (index == selectedIndex) MAX_SCALE else DEFAULT_SCALE
+        val finalBarHeight = size.height * selectedBarScale * (abs(value) / (maxValue - minValue))
         val barHeight = lerp(0f, finalBarHeight.toFloat(), progress[index].value)
 
         val top = if (value >= 0) baselineY - barHeight else baselineY
         val left = (barWidth + spacing) * index
-
-        val selectedBarScale = if (index == selectedIndex) MAX_SCALE else DEFAULT_SCALE
 
         drawRect(
             color = barColor,
             topLeft = Offset(x = left, y = top.toFloat()),
             size = Size(
                 width = barWidth * selectedBarScale,
-                height = barHeight * selectedBarScale
+                height = barHeight
             )
         )
     }

--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barstackedchart/BarStackedChart.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barstackedchart/BarStackedChart.kt
@@ -98,7 +98,7 @@ private fun DrawScope.drawBars(
         item.item.points.forEachIndexed { dataIndex, value ->
             val height = lerp(
                 0f,
-                (value.toFloat() / totalMaxValue.toFloat()) * size.height,
+                (value.toFloat() * selectedBarScale / totalMaxValue.toFloat()) * size.height,
                 progress[index].value
             )
             topOffset -= height
@@ -108,7 +108,7 @@ private fun DrawScope.drawBars(
                 topLeft = Offset(x = index * (barWidth + spacing), y = topOffset),
                 size = Size(
                     width = barWidth * selectedBarScale,
-                    height = height * selectedBarScale
+                    height = height
                 )
             )
         }


### PR DESCRIPTION
[before.webm](https://github.com/user-attachments/assets/310c9279-3c14-49a7-8bbc-db28d8506c2a)
[after.webm](https://github.com/user-attachments/assets/06dfaaec-7102-4f04-bf1f-3a187e0ede5c)

In before file, you can notice that the smaller section on the 4th bar becomes even smaller on hover. 
In after file, this is fixed so both of them proportionally grow bigger while anchoring to the same origin point. 

This fix is applied to both `BarChart` and  `BarStackedChart`