### PR TITLE
Improve/compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,7 @@ kotlin {
             implementation(libs.androidx.lifecycle.runtime.compose)
             implementation(libs.androidx.navigation.compose)
             implementation(libs.androidx.lifecycle.viewmodel.compose)
+            implementation(libs.koin.core)
             implementation(libs.koin.compose.viewmodel)
         }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.build.config)
     alias(libs.plugins.kover)
+    alias(libs.plugins.compose.compiler)
 }
 
 kotlin {
@@ -94,10 +95,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
 
-    compose {
-        kotlinCompilerPlugin.set(libs.versions.kotlinCompilerPlugin.get())
-    }
-
     kotlin {
         jvmToolchain(libs.versions.java.get().toInt())
     }
@@ -105,10 +102,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
         targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.kotlinCompilerExtensionVersion.get()
     }
 
     buildFeatures {

--- a/app/src/androidMain/kotlin/io/github/dautovicharis/charts/app/demo/ChartViewDemoStyle.android.kt
+++ b/app/src/androidMain/kotlin/io/github/dautovicharis/charts/app/demo/ChartViewDemoStyle.android.kt
@@ -1,0 +1,5 @@
+package io.github.dautovicharis.charts.app.demo
+
+import androidx.compose.ui.unit.Dp
+
+actual fun chartWidth() = Dp.Infinity

--- a/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/demo/ChartViewDemoStyle.kt
+++ b/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/demo/ChartViewDemoStyle.kt
@@ -9,7 +9,9 @@ object ChartViewDemoStyle {
 
     // We are changing the default ChartView style just for demo purposes
     @Composable
-    fun custom(width: Dp = Dp.Infinity): ChartViewStyle {
+    fun custom(width: Dp = chartWidth()): ChartViewStyle {
         return ChartViewDefaults.style(width = width)
     }
 }
+
+expect fun chartWidth(): Dp

--- a/app/src/iosMain/kotlin/MainViewController.kt
+++ b/app/src/iosMain/kotlin/MainViewController.kt
@@ -1,5 +1,5 @@
 import androidx.compose.ui.window.ComposeUIViewController
 
 fun MainViewController() = ComposeUIViewController {
-    MainView()
+    MainScreen()
 }

--- a/app/src/jsMain/kotlin/JsApp.kt
+++ b/app/src/jsMain/kotlin/JsApp.kt
@@ -1,12 +1,14 @@
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.CanvasBasedWindow
+import io.github.dautovicharis.charts.app.di.initKoin
 import org.jetbrains.skiko.wasm.onWasmReady
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main () {
+    initKoin()
     onWasmReady {
         CanvasBasedWindow("Kmp app") {
-            MainView()
+            MainScreen()
         }
     }
 }

--- a/app/src/jsMain/kotlin/io/github/dautovicharis/charts/app/demo/ChartViewDemoStyle.js.kt
+++ b/app/src/jsMain/kotlin/io/github/dautovicharis/charts/app/demo/ChartViewDemoStyle.js.kt
@@ -1,0 +1,5 @@
+package io.github.dautovicharis.charts.app.demo
+
+import androidx.compose.ui.unit.dp
+
+actual fun chartWidth() = 300.dp

--- a/app/src/jvmMain/kotlin/io/github/dautovicharis/charts/app/demo/ChartViewDemoStyle.jvm.kt
+++ b/app/src/jvmMain/kotlin/io/github/dautovicharis/charts/app/demo/ChartViewDemoStyle.jvm.kt
@@ -1,0 +1,5 @@
+package io.github.dautovicharis.charts.app.demo
+
+import androidx.compose.ui.unit.dp
+
+actual fun chartWidth() = 300.dp

--- a/app/src/jvmMain/kotlin/main.kt
+++ b/app/src/jvmMain/kotlin/main.kt
@@ -3,14 +3,15 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
-
+import io.github.dautovicharis.charts.app.di.initKoin
 
 fun main() = application {
+    initKoin()
     Window(
         title = "Charts Desktop Demo",
         state = rememberWindowState(width = 600.dp, height = 800.dp),
         onCloseRequest = ::exitApplication
     ) {
-        MainView()
+        MainScreen()
     }
 }

--- a/app/src/nativeMain/kotlin/io/github/dautovicharis/charts/app/demo/ChartViewDemoStyle.native.kt
+++ b/app/src/nativeMain/kotlin/io/github/dautovicharis/charts/app/demo/ChartViewDemoStyle.native.kt
@@ -1,0 +1,5 @@
+package io.github.dautovicharis.charts.app.demo
+
+import androidx.compose.ui.unit.Dp
+
+actual fun chartWidth() = Dp.Infinity

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.build.config) apply false
     alias(libs.plugins.sonarqube) apply true
     alias(libs.plugins.kover) apply true
+    alias(libs.plugins.compose.compiler) apply false
 }
 
 sonar {

--- a/charts/build.gradle.kts
+++ b/charts/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     signing
     alias(libs.plugins.mavenPublish)
     alias(libs.plugins.kover)
+    alias(libs.plugins.compose.compiler)
 }
 
 buildscript {
@@ -74,10 +75,6 @@ android {
         compose = true
     }
 
-    compose {
-        kotlinCompilerPlugin.set(libs.versions.kotlinCompilerPlugin.get())
-    }
-
     kotlin {
         jvmToolchain(libs.versions.java.get().toInt())
     }
@@ -85,10 +82,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
         targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.kotlinCompilerExtensionVersion.get()
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,9 +12,7 @@ androidx-lifecycle = "2.8.0"
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compatibility-and-versioning.html#kotlin-compatibility
 compose = "1.6.7"
 compose-plugin = "1.6.1"
-kotlinCompilerPlugin = "1.5.10.1"
 kotlin-multiplatform = "1.9.23"
-kotlinCompilerExtensionVersion = "1.5.9"
 
 # Documentation: https://kotlin.github.io/dokka/
 dokka = "1.9.20"
@@ -50,3 +48,5 @@ mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublis
 build-config = { id = "com.github.gmazzo.buildconfig", version.ref = "buildConfig" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+# https://developer.android.com/develop/ui/compose/compiler
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin-multiplatform" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,8 @@ sonarqube = "5.0.0.4638"
 # https://github.com/Kotlin/kotlinx-kover
 kover = "0.8.1"
 # https://insert-koin.io
-koin = "4.0.2"
+# https://mvnrepository.com/artifact/io.insert-koin/koin-bom
+koin-bom = "4.0.2"
 
 [libraries]
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
@@ -34,9 +35,10 @@ androidx-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycl
 androidx-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 dokka-doc = { group = "org.jetbrains.dokka", name="android-documentation-plugin", version.ref = "dokka" }
-dokka-versions = {group = "org.jetbrains.dokka", name = "versioning-plugin", version.ref = "dokka"}
-koin-android = {module = "io.insert-koin:koin-android", version.ref = "koin"}
-koin-compose-viewmodel = {module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin"}
+dokka-versions = {group = "org.jetbrains.dokka", name = "versioning-plugin", version.ref = "dokka" }
+koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin-bom" }
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin-bom" }
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin-bom" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,16 +3,17 @@
 java = "17"
 
 # Android gradle plugin version
-agp = "8.8.0"
+agp = "8.8.1"
 
 androidx-navigation = "2.7.0-alpha06"
 androidx-lifecycle = "2.8.0"
 
 # Kotlin compatibility
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compatibility-and-versioning.html#kotlin-compatibility
-compose = "1.6.7"
-compose-plugin = "1.6.1"
-kotlin-multiplatform = "1.9.23"
+compose = "1.7.6"
+compose-plugin = "1.7.3"
+# https://plugins.gradle.org/plugin/org.jetbrains.kotlin.multiplatform
+kotlin-multiplatform = "2.1.10"
 
 # Documentation: https://kotlin.github.io/dokka/
 dokka = "1.9.20"

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,7 +1,12 @@
 import SwiftUI
+import app
 
 @main
 struct iOSApp: App {
+    init() {
+        KoinAppKt.doInitKoin()
+    }
+    
 	var body: some Scene {
 		WindowGroup {
 			ContentView()


### PR DESCRIPTION
- Migrated to the Compose Compiler Plugin (https://kotlinlang.org/docs/compose-compiler-migration-guide.html).

- Updated dependencies:
     - AGP to version 8.8.1
     - Kotlin to version 2.1.10
     - Compose Multiplatform to version 1.7.3
     - Jetpack Compose to version 1.7.6
     - Switched Koin to use BOM for better dependency management
- Fixed Koin initialization issues for JS, JVM, and iOS.
- Adjusted chart size for JS and JVM clients to avoid fullscreen (for demo purposes).