### PR TITLE
Fix colors state update

### DIFF
--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/BarStackedChartView.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/BarStackedChartView.kt
@@ -2,6 +2,7 @@ package io.github.dautovicharis.charts
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -54,13 +55,11 @@ private fun ChartContent(dataSet: MultiChartDataSet, style: StackedBarChartStyle
     var title by remember { mutableStateOf(dataSet.data.title) }
     var labels by remember { mutableStateOf(listOf<String>()) }
 
-    val colors by remember {
-        mutableStateOf(
-            style.barColors.ifEmpty {
-                generateColorShades(style.barColor, dataSet.data.getFirstPointsSize())
-            }
-        )
-    }
+    val colors = derivedStateOf {
+        style.barColors.ifEmpty {
+            generateColorShades(style.barColor, dataSet.data.getFirstPointsSize())
+        }
+    }.value
 
     ChartView(chartViewsStyle = style.chartViewStyle) {
         Text(

--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartViewImpl.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartViewImpl.kt
@@ -2,6 +2,7 @@ package io.github.dautovicharis.charts.internal.linechart
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,17 +37,16 @@ internal fun LineChartViewImpl(
         var title by remember { mutableStateOf(data.title) }
         var labels by remember { mutableStateOf(listOf<String>()) }
 
-        val lineColors by remember {
-            mutableStateOf(
-                if (data.hasSingleItem()) {
-                    listOf(style.lineColor)
-                } else if (style.lineColors.isEmpty()) {
-                    generateColorShades(style.lineColor, data.items.size)
-                } else {
-                    style.lineColors
-                }
-            )
-        }
+        val lineColors = derivedStateOf {
+            if (data.hasSingleItem()) {
+                listOf(style.lineColor)
+            } else if (style.lineColors.isEmpty()) {
+                generateColorShades(style.lineColor, data.items.size)
+            } else {
+                style.lineColors
+            }
+        }.value
+
         ChartView(chartViewsStyle = style.chartViewStyle) {
             Text(
                 modifier = style.chartViewStyle.modifierTopTitle


### PR DESCRIPTION
Replaced `mutableStateOf` with `derivedStateOf` to ensure `lineColors` is always derived correctly from `style`.
