### PR TITLE
Reset submenu state before navigate

### DIFF
--- a/app/src/commonMain/kotlin/MainScreen.kt
+++ b/app/src/commonMain/kotlin/MainScreen.kt
@@ -101,6 +101,7 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
 
         LaunchedEffect(menuState.value.selectedSubmenu) {
             menuState.value.selectedSubmenu?.let {
+                viewModel.onSubmenuUnselected()
                 navController.navigate(it.route)
             }
         }

--- a/app/src/commonMain/kotlin/MainViewModel.kt
+++ b/app/src/commonMain/kotlin/MainViewModel.kt
@@ -59,6 +59,12 @@ class MainViewModel : ViewModel() {
         }
     }
 
+    fun onSubmenuUnselected() {
+        _menuState.update {
+            it.copy(selectedSubmenu = null)
+        }
+    }
+
     fun onMenuToggle(index: Int) {
         _menuState.update { state ->
             val newExpandedMenuIndex = if (state.expandedMenuIndex == index) {


### PR DESCRIPTION
We share `MainViewModel` across all clients (mobile, desktop, web). However, we have additional menu customizations for the JS client to enable more browser-friendly navigation.

With this PR, I introduced changes in the `MainViewModel` that are only related to clients using `NavController`.