### PR TITLE
Automatically download required JDK

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,12 @@ pluginManagement {
     }
 }
 
+plugins {
+    // https://github.com/gradle/foojay-toolchains
+    // Automatically download required JDK
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         google()


### PR DESCRIPTION
Added `org.gradle.toolchains.foojay-resolver-convention` plugin to `settings.gradle.kts`
This allows `Gradle` to automatically download the required JDK if it doesn't exist locally.

The build was previously failing with the following error:
`Cannot find a Java installation on your machine matching this tasks requirements: {languageVersion=17, vendor=any vendor, implementation=vendor-specific} for MAC_OS on x86_64.`