### PR TITLE
Fix proguard

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,8 +86,11 @@ android {
     }
 
     buildTypes {
-        getByName("release") {
+        getByName("debug") {
             isMinifyEnabled = false
+        }
+        getByName("release") {
+            isMinifyEnabled = true
         }
     }
 

--- a/charts/build.gradle.kts
+++ b/charts/build.gradle.kts
@@ -69,6 +69,8 @@ android {
         compileSdk = Config.compileSdk
         minSdk = Config.minSdk
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        consumerProguardFiles("proguard-rules.pro")
     }
 
     buildFeatures {

--- a/charts/proguard-rules.pro
+++ b/charts/proguard-rules.pro
@@ -1,0 +1,11 @@
+# Dokka-related classes that can be safely ignored
+-dontwarn org.jetbrains.dokka.**
+-dontwarn com.fasterxml.jackson.**
+-dontwarn freemarker.**
+-dontwarn com.sun.org.apache.xml.**
+-dontwarn java.beans.**
+-dontwarn javax.swing.**
+-dontwarn org.apache.xml.**
+-dontwarn org.jaxen.**
+-dontwarn org.python.core.**
+-dontwarn org.zeroturnaround.**


### PR DESCRIPTION
This pull request makes several improvements to the build configuration and ProGuard settings for the `charts` module and updates the minification settings for the main app module. The primary focus is on optimizing release builds and ensuring that unnecessary warnings from documentation-related dependencies are suppressed.

**Build configuration improvements:**

* In `app/build.gradle.kts`, enabled code minification (`isMinifyEnabled = true`) for the `release` build type and explicitly set minification to false for the `debug` build type, ensuring proper optimization and debugging behavior for each build variant.
* In `charts/build.gradle.kts`, added `consumerProguardFiles("proguard-rules.pro")` to include custom ProGuard rules for the `charts` module, improving consumer-side code shrinking and obfuscation.

**ProGuard rules enhancements:**

* Added a new `proguard-rules.pro` file to the `charts` module with rules to suppress warnings for Dokka and other documentation-related dependencies, preventing unnecessary build warnings.

Fixes #143