### PR TITLE
Update JS demo to use ES modules and full-screen layout

### DIFF
--- a/app/src/jsMain/resources/index.html
+++ b/app/src/jsMain/resources/index.html
@@ -2,13 +2,27 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>ComposeImageLoader</title>
-    <script src="skiko.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Charts Demo</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        html, body {
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+        }
+        #Charts {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
 </head>
 <body>
-<div>
-    <canvas id="ComposeTarget" width="800" height="600"></canvas>
-</div>
-<script src="Charts.js"></script>
+<div id="Charts"></div>
+<script type="module" src="Charts.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This pull request updates the main HTML entry point for the web application, improving its layout for a charts demo and modernizing how scripts are loaded. The most important changes are grouped below:

Layout and styling improvements:

* Added a responsive CSS style block to ensure the chart container (`#Charts`) and the page fill the entire viewport and have no default margin or padding.
* Replaced the old canvas container with a single `div` element (`id="Charts"`) for rendering charts.

Project branding and metadata:

* Changed the page title from "ComposeImageLoader" to "Charts Demo" and added a viewport meta tag for better mobile support.

Script loading modernization:

* Updated the script tag for `Charts.js` to use `type="module"` for ES module support and removed the legacy `skiko.js` script.