### PR TITLE
fix(linechart): keep drag point on curve

### DIFF
--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChart.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChart.kt
@@ -289,7 +289,8 @@ private fun DrawScope.tryDrawDragPoints(
         val nearestPoint = findNearestPoint(
             touchX = touchX,
             scaledValues = values,
-            size = size
+            size = size,
+            bezier = style.bezier
         )
 
         val draggingCircleOffset = Offset(

--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartHelpers.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChartHelpers.kt
@@ -7,24 +7,100 @@ import androidx.compose.ui.util.lerp
 internal fun findNearestPoint(
     touchX: Float,
     scaledValues: List<Float>,
-    size: Size
+    size: Size,
+    bezier: Boolean
 ): Offset {
 
+    if (scaledValues.isEmpty()) {
+        return Offset(0f, 0f)
+    }
+
+    val clampedX = touchX.coerceIn(0f, size.width)
+    if (scaledValues.size == 1 || size.width == 0f) {
+        return Offset(clampedX, size.height - scaledValues.first())
+    }
+
     val lastIndex = scaledValues.size - 1
-    val index = (touchX / size.width * lastIndex)
+    val step = size.width / lastIndex
+    val index = (clampedX / step)
         .toInt()
         .coerceIn(0, lastIndex)
 
-    val step = size.width / lastIndex
-    val pointBefore = scaledValues[index]
-    val pointAfter = when (index + 1 < scaledValues.size) {
-        true -> scaledValues[index + 1]
-        else -> pointBefore
+    if (!bezier || index == lastIndex) {
+        val pointBefore = scaledValues[index]
+        val pointAfter = when (index + 1 < scaledValues.size) {
+            true -> scaledValues[index + 1]
+            else -> pointBefore
+        }
+
+        val ratio = ((clampedX - (index * step)) / step).coerceIn(0f, 1f)
+        val interpolatedY = lerp(pointBefore, pointAfter, ratio)
+        return Offset(clampedX, size.height - interpolatedY)
     }
 
-    val ratio = (touchX % step) / step
-    val interpolatedY = lerp(pointBefore, pointAfter, ratio.coerceIn(0f, 1f))
-    return Offset(touchX, size.height - interpolatedY)
+    val nextIndex = index + 1
+    val prevX = index * step
+    val currentX = nextIndex * step
+    val prevY = size.height - scaledValues[index]
+    val currentY = size.height - scaledValues[nextIndex]
+
+    val controlPointDiv = 2.2f
+    val controlX1 = prevX + (currentX - prevX) / controlPointDiv
+    val controlX2 = currentX - (currentX - prevX) / controlPointDiv
+
+    val targetX = clampedX.coerceIn(prevX, currentX)
+    val t = solveBezierTForX(
+        targetX = targetX,
+        x0 = prevX,
+        x1 = controlX1,
+        x2 = controlX2,
+        x3 = currentX
+    )
+    val y = cubicBezier(
+        t = t,
+        p0 = prevY,
+        p1 = prevY,
+        p2 = currentY,
+        p3 = currentY
+    )
+    return Offset(targetX, y)
+}
+
+private fun solveBezierTForX(
+    targetX: Float,
+    x0: Float,
+    x1: Float,
+    x2: Float,
+    x3: Float
+): Float {
+    var low = 0f
+    var high = 1f
+    repeat(20) {
+        val mid = (low + high) / 2f
+        val x = cubicBezier(mid, x0, x1, x2, x3)
+        if (x < targetX) {
+            low = mid
+        } else {
+            high = mid
+        }
+    }
+    return (low + high) / 2f
+}
+
+private fun cubicBezier(
+    t: Float,
+    p0: Float,
+    p1: Float,
+    p2: Float,
+    p3: Float
+): Float {
+    val oneMinusT = 1f - t
+    val oneMinusT2 = oneMinusT * oneMinusT
+    val t2 = t * t
+    return (oneMinusT2 * oneMinusT * p0) +
+        (3f * oneMinusT2 * t * p1) +
+        (3f * oneMinusT * t2 * p2) +
+        (t2 * t * p3)
 }
 
 internal fun scaleValues(

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/helpers/LineChartHelpersTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/helpers/LineChartHelpersTest.kt
@@ -26,7 +26,12 @@ class LineChartHelpersTest {
 
         testCases.forEach { entry: Map.Entry<Triple<Float, List<Float>, Size>, Offset> ->
             // Act
-            val nearestPoint = findNearestPoint(entry.key.first, entry.key.second, entry.key.third)
+            val nearestPoint = findNearestPoint(
+                touchX = entry.key.first,
+                scaledValues = entry.key.second,
+                size = entry.key.third,
+                bezier = false
+            )
 
             // Assert
             assertTrue { nearestPoint == entry.value }


### PR DESCRIPTION
Fixes #91

Summary:
Fix drag-point positioning so it follows Bezier curves, matching the rendered line for both single and multi-line charts.

Changes:
- compute Bezier-accurate drag positions in `findNearestPoint`
- pass `bezier` flag through to drag-point logic
- update helper tests to include the new parameter

Notes/Risk:
- Low risk; behavior is unchanged for non-Bezier lines.