### PR TITLE
fix(charts): avoid scroll conflicts with gestures

### DIFF
--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barchart/BarChart.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barchart/BarChart.kt
@@ -3,7 +3,7 @@ package io.github.dautovicharis.charts.internal.barchart
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -56,8 +56,17 @@ internal fun BarChart(
     Canvas(modifier = style.modifier
         .testTag(TestTags.BAR_CHART)
         .pointerInput(Unit) {
-        detectDragGestures(
-            onDrag = { change, _ ->
+        detectHorizontalDragGestures(
+            onDragStart = { offset ->
+                selectedIndex =
+                    getSelectedIndex(
+                        position = offset,
+                        dataSize = chartData.points.count(),
+                        canvasSize = size
+                    )
+                onValueChanged(selectedIndex)
+            },
+            onHorizontalDrag = { change, _ ->
                 selectedIndex =
                     getSelectedIndex(
                         position = change.position,
@@ -68,6 +77,10 @@ internal fun BarChart(
                 change.consume()
             },
             onDragEnd = {
+                selectedIndex = NO_SELECTION
+                onValueChanged(NO_SELECTION)
+            },
+            onDragCancel = {
                 selectedIndex = NO_SELECTION
                 onValueChanged(NO_SELECTION)
             }

--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barstackedchart/StackedBarChart.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barstackedchart/StackedBarChart.kt
@@ -3,7 +3,7 @@ package io.github.dautovicharis.charts.internal.barstackedchart
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -54,8 +54,17 @@ internal fun StackedBarChart(
         modifier = style.modifier
             .testTag(TestTags.STACKED_BAR_CHART)
             .pointerInput(Unit) {
-            detectDragGestures(
-                onDrag = { change, _ ->
+            detectHorizontalDragGestures(
+                onDragStart = { offset ->
+                    selectedIndex =
+                        getSelectedIndex(
+                            position = offset,
+                            dataSize = data.items.count(),
+                            canvasSize = size
+                        )
+                    onValueChanged(selectedIndex)
+                },
+                onHorizontalDrag = { change, _ ->
                     selectedIndex =
                         getSelectedIndex(
                             position = change.position,
@@ -63,8 +72,13 @@ internal fun StackedBarChart(
                             canvasSize = size
                         )
                     onValueChanged(selectedIndex)
+                    change.consume()
                 },
                 onDragEnd = {
+                    selectedIndex = NO_SELECTION
+                    onValueChanged(NO_SELECTION)
+                },
+                onDragCancel = {
                     selectedIndex = NO_SELECTION
                     onValueChanged(NO_SELECTION)
                 }

--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChart.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/linechart/LineChart.kt
@@ -2,7 +2,7 @@ package io.github.dautovicharis.charts.internal.linechart
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableFloatState
 import androidx.compose.runtime.MutableState
@@ -53,15 +53,19 @@ internal fun LineChart(
             show = true
         }
         .pointerInput(Unit) {
-            detectDragGestures(
-                onDragStart = {
+            detectHorizontalDragGestures(
+                onDragStart = { offset ->
                     dragging.value = true
+                    touchX.floatValue = offset.x
                 },
-                onDrag = { change, _ ->
+                onHorizontalDrag = { change, _ ->
                     touchX.floatValue = change.position.x
                     change.consume()
                 },
                 onDragEnd = {
+                    dragging.value = false
+                },
+                onDragCancel = {
                     dragging.value = false
                 }
             )

--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/piechart/PieChart.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/piechart/PieChart.kt
@@ -2,7 +2,8 @@ package io.github.dautovicharis.charts.internal.piechart
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -71,20 +72,49 @@ internal fun PieChart(
         .testTag(TestTags.PIE_CHART)
         .onGloballyPositioned { show = true }
         .pointerInput(Unit) {
-            detectDragGestures(onDragEnd = {
-                selectedIndex = NO_SELECTION
-                onSliceTouched(selectedIndex)
-            }) { change, _ ->
+            detectTapGestures { offset ->
                 selectedIndex =
                     getSelectedIndex(
-                        pointX = change.position.x,
-                        pointY = change.position.y,
+                        pointX = offset.x,
+                        pointY = offset.y,
                         size = size,
                         slices = slices
                     )
                 onSliceTouched(selectedIndex)
-                change.consume()
             }
+        }
+        .pointerInput(Unit) {
+            detectDragGesturesAfterLongPress(
+                onDragStart = { offset ->
+                    selectedIndex =
+                        getSelectedIndex(
+                            pointX = offset.x,
+                            pointY = offset.y,
+                            size = size,
+                            slices = slices
+                        )
+                    onSliceTouched(selectedIndex)
+                },
+                onDrag = { change, _ ->
+                    selectedIndex =
+                        getSelectedIndex(
+                            pointX = change.position.x,
+                            pointY = change.position.y,
+                            size = size,
+                            slices = slices
+                        )
+                    onSliceTouched(selectedIndex)
+                    change.consume()
+                },
+                onDragEnd = {
+                    selectedIndex = NO_SELECTION
+                    onSliceTouched(selectedIndex)
+                },
+                onDragCancel = {
+                    selectedIndex = NO_SELECTION
+                    onSliceTouched(selectedIndex)
+                }
+            )
         }
         .drawWithCache {
             onDrawBehind {

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/PieChartTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/PieChartTest.kt
@@ -64,13 +64,10 @@ class PieChartTest {
             val sliceMiddlePosition =
                 getCoordinatesForSlice(index = index, size = size, slices = slices)
             onNodeWithTag(TestTags.PIE_CHART).performTouchInput {
-                down(Offset(0f, 0f))
-                moveTo(sliceMiddlePosition)
-            }
-            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(value).isDisplayed()
-            onNodeWithTag(TestTags.PIE_CHART).performTouchInput {
+                down(sliceMiddlePosition)
                 up()
             }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(value).isDisplayed()
         }
     }
 
@@ -139,13 +136,10 @@ class PieChartTest {
             val sliceMiddlePosition =
                 getCoordinatesForSlice(index = index, size = size, slices = slices)
             onNodeWithTag(TestTags.PIE_CHART).performTouchInput {
-                down(Offset(0f, 0f))
-                moveTo(sliceMiddlePosition)
-            }
-            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(value).isDisplayed()
-            onNodeWithTag(TestTags.PIE_CHART).performTouchInput {
+                down(sliceMiddlePosition)
                 up()
             }
+            onNodeWithTag(TestTags.CHART_TITLE).assertTextEquals(value).isDisplayed()
         }
     }
 }


### PR DESCRIPTION
Fixes #92

Summary:
Prevent chart interactions from blocking vertical scrolling by restricting line/bar/stacked to horizontal drags and switching pie to tap + long-press drag selection.

Changes:
- use horizontal-only drag detection for line, bar, and stacked bar charts
- add tap selection and long-press drag for pie charts to avoid scroll conflicts
- update pie UI tests to use tap input

Notes/Risk:
- Low risk; gesture handling changed but rendering logic is unchanged.
