### PR TITLE
fix(bar): correct min required error message

### DIFF
--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/DataValidation.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/DataValidation.kt
@@ -72,7 +72,7 @@ internal fun validateBarData(data: ChartData): List<String> {
 
     if (pointsSize < MIN_REQUIRED_BAR) {
         val validationError =
-            ValidationErrors.RULE_DATA_POINTS_LESS_THAN_MIN.format(MIN_REQUIRED_PIE)
+            ValidationErrors.RULE_DATA_POINTS_LESS_THAN_MIN.format(MIN_REQUIRED_BAR)
         validationErrors.add(validationError)
         return validationErrors
     }

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/BarChartTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/BarChartTest.kt
@@ -10,7 +10,7 @@ import io.github.dautovicharis.charts.BarChart
 import io.github.dautovicharis.charts.model.ChartDataSet
 import io.github.dautovicharis.charts.internal.common.model.ChartDataType
 import io.github.dautovicharis.charts.internal.TestTags
-import io.github.dautovicharis.charts.internal.ValidationErrors.MIN_REQUIRED_LINE
+import io.github.dautovicharis.charts.internal.ValidationErrors.MIN_REQUIRED_BAR
 import io.github.dautovicharis.charts.internal.ValidationErrors.RULE_DATA_POINTS_LESS_THAN_MIN
 import io.github.dautovicharis.charts.internal.format
 import io.github.dautovicharis.charts.mock.MockTest.TITLE
@@ -43,7 +43,7 @@ class BarChartTest {
             items = ChartDataType.FloatData(listOf(1f)),
             title = TITLE
         )
-        val expectedError = RULE_DATA_POINTS_LESS_THAN_MIN.format(MIN_REQUIRED_LINE)
+        val expectedError = RULE_DATA_POINTS_LESS_THAN_MIN.format(MIN_REQUIRED_BAR)
 
         setContent {
             BarChart(dataSet)


### PR DESCRIPTION
Summary:
Fixes the bar chart validation error to report the bar minimum requirement and updates the bar chart UI test expectation.

Changes:
- Use `MIN_REQUIRED_BAR` in bar chart validation errors.
- Update the bar chart test expected error message accordingly.


Risk:
Low. Messaging-only change with a matching test update.
