### PR TITLE
fix(bar): account for spacing in selection

### DIFF
--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barchart/BarChart.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barchart/BarChart.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.util.lerp
 import io.github.dautovicharis.charts.internal.ANIMATION_TARGET
@@ -52,6 +53,7 @@ internal fun BarChart(
     val maxValue = remember { chartData.points.max() }
     val minValue = remember { chartData.points.min() }
     var selectedIndex by remember { mutableIntStateOf(NO_SELECTION) }
+    val spacingPx = with(LocalDensity.current) { style.space.toPx() }
 
     Canvas(modifier = style.modifier
         .testTag(TestTags.BAR_CHART)
@@ -62,7 +64,8 @@ internal fun BarChart(
                     getSelectedIndex(
                         position = offset,
                         dataSize = chartData.points.count(),
-                        canvasSize = size
+                        canvasSize = size,
+                        spacingPx = spacingPx
                     )
                 onValueChanged(selectedIndex)
             },
@@ -71,7 +74,8 @@ internal fun BarChart(
                     getSelectedIndex(
                         position = change.position,
                         dataSize = chartData.points.count(),
-                        canvasSize = size
+                        canvasSize = size,
+                        spacingPx = spacingPx
                     )
                 onValueChanged(selectedIndex)
                 change.consume()

--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barchart/BarChartHelpers.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barchart/BarChartHelpers.kt
@@ -2,9 +2,20 @@ package io.github.dautovicharis.charts.internal.barchart
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntSize
+import kotlin.math.max
 
-internal fun getSelectedIndex(position: Offset, dataSize: Int, canvasSize: IntSize): Int {
-    val barWidth = canvasSize.width / dataSize
-    val index = (position.x / (barWidth)).toInt()
+internal fun getSelectedIndex(
+    position: Offset,
+    dataSize: Int,
+    canvasSize: IntSize,
+    spacingPx: Float
+): Int {
+    if (dataSize <= 0 || canvasSize.width <= 0) return 0
+
+    val totalSpacing = spacingPx * (dataSize - 1)
+    val availableWidth = max(1f, canvasSize.width - totalSpacing)
+    val barWidth = availableWidth / dataSize
+    val unitWidth = barWidth + spacingPx
+    val index = (position.x / unitWidth).toInt()
     return index.coerceIn(0, dataSize - 1)
 }

--- a/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barstackedchart/StackedBarChart.kt
+++ b/charts/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/barstackedchart/StackedBarChart.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.util.lerp
 import io.github.dautovicharis.charts.internal.ANIMATION_TARGET
@@ -40,6 +41,7 @@ internal fun StackedBarChart(
         data.items.map { animationState }
     }
     var selectedIndex by remember { mutableIntStateOf(-1) }
+    val spacingPx = with(LocalDensity.current) { style.space.toPx() }
 
     progress.forEachIndexed { index, _ ->
         LaunchedEffect(index) {
@@ -60,7 +62,8 @@ internal fun StackedBarChart(
                         getSelectedIndex(
                             position = offset,
                             dataSize = data.items.count(),
-                            canvasSize = size
+                            canvasSize = size,
+                            spacingPx = spacingPx
                         )
                     onValueChanged(selectedIndex)
                 },
@@ -69,7 +72,8 @@ internal fun StackedBarChart(
                         getSelectedIndex(
                             position = change.position,
                             dataSize = data.items.count(),
-                            canvasSize = size
+                            canvasSize = size,
+                            spacingPx = spacingPx
                         )
                     onValueChanged(selectedIndex)
                     change.consume()

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/helpers/BarChartHelpersTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/helpers/BarChartHelpersTest.kt
@@ -12,6 +12,7 @@ class BarChartHelpersTest {
         val position: Offset,
         val values: List<Double>,
         val size: IntSize,
+        val spacingPx: Float,
         val expectedIndex: Int
     )
 
@@ -23,25 +24,40 @@ class BarChartHelpersTest {
                 position = Offset(500.0F, 500.0F),
                 values = listOf(1.0, 2.0, 3.0, 4.0),
                 size = IntSize(1000, 1000),
+                spacingPx = 0f,
                 expectedIndex = 2
             ),
             GetSelectedIndexTestCase(
                 position = Offset(900.0F, 900.0F),
                 values = listOf(100.0, 200.0, 300.0, 400.0, 500.0),
                 size = IntSize(1500, 1500),
+                spacingPx = 0f,
                 expectedIndex = 3
             ),
             GetSelectedIndexTestCase(
                 position = Offset(400.0F, 600.0F),
                 values = listOf(50.0, 100.0, 150.0, 200.0, 250.0),
                 size = IntSize(800, 1200),
+                spacingPx = 0f,
+                expectedIndex = 2
+            ),
+            GetSelectedIndexTestCase(
+                position = Offset(520.0F, 500.0F),
+                values = listOf(1.0, 2.0, 3.0, 4.0),
+                size = IntSize(1000, 1000),
+                spacingPx = 20f,
                 expectedIndex = 2
             )
         )
 
         testCases.forEach { testCase ->
             // Act
-            val result = getSelectedIndex(testCase.position, testCase.values.size, testCase.size)
+            val result = getSelectedIndex(
+                testCase.position,
+                testCase.values.size,
+                testCase.size,
+                testCase.spacingPx
+            )
 
             // Assert
             assertTrue { result == testCase.expectedIndex }


### PR DESCRIPTION
Summary: Make bar and stacked bar selection respect configured spacing so drag selection maps to the correct bar.
Changes:
- Account for spacing in bar/stacked selection index calculation.
- Pass spacing in pixels from chart styles to selection helper.
- Extend helper unit test coverage for non-zero spacing.
Notes/Risk: Low. Interaction-only fix; rendering unchanged.
