### PR TITLE
docs(agent): clarify PR creation steps

### DIFF
--- a/.agent/create-pr.md
+++ b/.agent/create-pr.md
@@ -17,28 +17,35 @@ Use this file as the **single source of truth** for an agent to ship the current
 - **Branch name**: `<type>/<short-kebab>` (examples: `feat/add-template-gallery`, `fix/pdf-export-crash`)
 - **Commit message**: Conventional Commits (`type(scope): subject`)
 - **PR title**: same as commit header
-- **Remote**: Use `upstream` if it exists; otherwise `origin`
+- **Base remote (PR target)**: use `upstream` if it exists; otherwise `origin`
+- **Head remote (push)**: use `origin` if it exists; otherwise `upstream`
+- **Upstream repo**: `dautovicharis/charts`
 - **Base branch**: `main`
 
 ## Workflow (simple)
 
 1. Infer the summary from context (do not ask the user).
-2. Create a new branch: `git checkout -b <branch>`.
-3. Stage changes: `git add -A`
-4. Show status and staged diff: `git status`, `git diff --staged`
-5. Commit (skip pre-commit checks): `SKIP_PRE_COMMIT=1 git commit -m "<commit>"`
-6. Push: `git push -u origin <branch>`
+2. Decide remotes (base vs head) using the conventions above.
+3. Create a new branch: `git checkout -b <branch>`.
+4. Stage changes: `git add -A`
+5. Commit: `git commit -m "<commit>"`
+6. Push: `git push -u <head-remote> <branch>`
 7. Create a temp PR body file (auto-cleaned at the end of this flow):
    - `PR_BODY_FILE="$(mktemp -t pr-body.XXXXXX.md)"`
 8. Write PR body to `$PR_BODY_FILE` (use the template below).
 9. Create PR (GitHub CLI), then delete the temp file:
-   - `gh pr create --base main --head <branch> --title "<title>" --body-file "$PR_BODY_FILE"`
+   - Use the upstream repo as the PR target.
+   - `gh pr create --repo dautovicharis/charts --base main --head <branch> --title "<title>" --body-file "$PR_BODY_FILE"`
    - `rm -f "$PR_BODY_FILE"`
 10. Output the PR URL.
 
 ## PR body template (short)
 
-Summary: <one paragraph>
-Changes:
+## Summary
+<one paragraph>
+
+## Changes
 - <bullets>
-Notes/Risk: <if any>
+
+## Notes/Risk
+- <if any; otherwise say "None">


### PR DESCRIPTION
## Summary
Update PR creation instructions to reflect always-available upstream and simplify the create step.

## Changes
- Clarify upstream vs origin roles and hard-code upstream repo for PR creation.
- Remove unnecessary status/diff and pre-commit hook references.
- Improve PR body formatting with section headers.

## Notes/Risk
- None
