### PR TITLE
fix(docs): add remote inference for static fetch

### DIFF
--- a/scripts/fetch-docs-static.sh
+++ b/scripts/fetch-docs-static.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 REMOTE="${DOCS_STATIC_REMOTE:-origin}"
+REMOTE_URL="${DOCS_STATIC_REMOTE_URL:-}"
 BRANCH="${DOCS_STATIC_BRANCH:-docs-static}"
 SKIP="${DOCS_SKIP_STATIC_FETCH:-}"
 
@@ -20,6 +21,51 @@ fi
 if ! git -C "${REPO_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "Not a git repository; skipping docs/static fetch." >&2
   exit 0
+fi
+
+infer_remote_url() {
+  if [[ -n "${VERCEL_GIT_REPO_OWNER:-}" && -n "${VERCEL_GIT_REPO_SLUG:-}" ]]; then
+    case "${VERCEL_GIT_PROVIDER:-}" in
+      github)
+        echo "https://github.com/${VERCEL_GIT_REPO_OWNER}/${VERCEL_GIT_REPO_SLUG}.git"
+        return 0
+        ;;
+      gitlab)
+        echo "https://gitlab.com/${VERCEL_GIT_REPO_OWNER}/${VERCEL_GIT_REPO_SLUG}.git"
+        return 0
+        ;;
+      bitbucket)
+        echo "https://bitbucket.org/${VERCEL_GIT_REPO_OWNER}/${VERCEL_GIT_REPO_SLUG}.git"
+        return 0
+        ;;
+    esac
+  fi
+
+  if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+    echo "https://github.com/${GITHUB_REPOSITORY}.git"
+    return 0
+  fi
+
+  if [[ -n "${CI_PROJECT_URL:-}" ]]; then
+    echo "${CI_PROJECT_URL}"
+    return 0
+  fi
+
+  return 1
+}
+
+if ! git -C "${REPO_ROOT}" remote get-url "${REMOTE}" >/dev/null 2>&1; then
+  if [[ -z "${REMOTE_URL}" ]]; then
+    REMOTE_URL="$(infer_remote_url || true)"
+  fi
+
+  if [[ -n "${REMOTE_URL}" ]]; then
+    echo "Adding git remote ${REMOTE} -> ${REMOTE_URL}..."
+    git -C "${REPO_ROOT}" remote add "${REMOTE}" "${REMOTE_URL}"
+  else
+    echo "Remote ${REMOTE} not configured; skipping docs/static fetch." >&2
+    exit 0
+  fi
 fi
 
 echo "Fetching docs/static from ${REMOTE}/${BRANCH}..."


### PR DESCRIPTION
## Summary
Ensure the docs static fetch step can add a missing git remote in CI so builds succeed when `origin` is not configured.

## Changes
- infer a remote URL from CI metadata or `DOCS_STATIC_REMOTE_URL`
- add the remote before fetching `docs-static` when missing
- keep the fetch behavior unchanged when the remote already exists

## Notes/Risk
- None
