### PR TITLE
fix(deploy): set vercel docs app root

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "docs/docs-app/package.json",
+      "use": "@vercel/next"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Point Vercel at the docs Next.js app so deployments serve documentation instead of an empty root, fixing the 404.

## Changes
- add vercel.json to build docs/docs-app with @vercel/next

## Notes/Risk
- None
