### PR TITLE
fix(deploy): stop ignoring docs app

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -14,13 +14,13 @@ build/
 .vscode/
 .DS_Store
 
-# Non-docs modules
-androidApp/
-app/
-charts/
-iosApp/
-buildSrc/
-gradle/
+# Non-docs modules (root only)
+/androidApp/
+/app/
+/charts/
+/iosApp/
+/buildSrc/
+/gradle/
 
 # Generated docs assets (fetched from orphan branch during build)
 docs/static/


### PR DESCRIPTION
## Summary
Allow the docs Next.js app under docs/docs-app to be included in Vercel uploads by anchoring root ignores, fixing missing routes/404s.

## Changes
- anchor non-docs ignores in .vercelignore to repo root

## Notes/Risk
- None
