### PR TITLE
fix(deploy): drop standalone output

### DIFF
--- a/docs/docs-app/next.config.ts
+++ b/docs/docs-app/next.config.ts
@@ -1,9 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // Enable static exports for Vercel
-  output: 'standalone',
-  
   // Enable trailing slashes for clean URLs
   trailingSlash: false,
   


### PR DESCRIPTION
## Summary
Remove the standalone output setting so Vercel treats the docs app as a standard Next.js build and deploys routes/functions.

## Changes
- drop output: "standalone" from docs/docs-app/next.config.ts

## Notes/Risk
- None
