### PR TITLE
fix(deploy): remove legacy vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,0 @@
-{
-  "version": 2,
-  "builds": [
-    {
-      "src": "docs/docs-app/package.json",
-      "use": "@vercel/next"
-    }
-  ]
-}


### PR DESCRIPTION
## Summary
Remove the legacy root vercel.json (builds/use) so Vercel relies on project Root Directory settings for the docs Next.js app.

## Changes
- delete root vercel.json

## Notes/Risk
- None
