### PR TITLE
docs(snapshot): update 2.0.2-SNAPSHOT index

### DIFF
--- a/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/MainScreen.kt
+++ b/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/MainScreen.kt
@@ -1,9 +1,17 @@
 package io.github.dautovicharis.charts.app
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Tune
@@ -18,10 +26,17 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -30,10 +45,17 @@ import chartsproject.app.generated.resources.Res
 import chartsproject.app.generated.resources.cd_navigate_back
 import chartsproject.app.generated.resources.cd_open_settings
 import io.github.dautovicharis.charts.app.library.BuildConfig
+import io.github.dautovicharis.charts.app.ui.composable.InteractiveSurfaceCallbacks
+import io.github.dautovicharis.charts.app.ui.composable.LocalInteractiveSurfaceCallbacks
 import io.github.dautovicharis.charts.app.ui.theme.AppTheme
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
+
+private val WideLayoutBreakpoint = 980.dp
+private val SettingsRailWidth = 320.dp
+private val SettingsEdgeOpenZoneWidth = 20.dp
+private val SettingsEdgeOpenDragThreshold = 28.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -45,55 +67,129 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
     val scope = rememberCoroutineScope()
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
     val canNavigateBack = currentBackStackEntry?.destination?.route != ChartDestination.MainScreen.ROUTE
+    var activeInteractiveSurfaces by remember { mutableIntStateOf(0) }
+    val interactionCallbacks =
+        remember {
+            InteractiveSurfaceCallbacks(
+                onInteractionStart = {
+                    activeInteractiveSurfaces += 1
+                },
+                onInteractionEnd = {
+                    activeInteractiveSurfaces = (activeInteractiveSurfaces - 1).coerceAtLeast(0)
+                },
+            )
+        }
 
     AppTheme(
         theme = themeState.selectedTheme,
         useDynamicColors = themeState.useDynamicColors,
         darkTheme = viewModel.resolveDarkTheme(isSystemInDarkTheme()),
     ) {
-        ModalNavigationDrawer(
-            drawerState = drawerState,
-            drawerContent = {
-                SettingsDrawerContent(
-                    themeState = themeState,
-                    onThemeSelected = viewModel::onThemeSelected,
-                    onDarkModeToggle = viewModel::toggleDarkMode,
-                    onDynamicToggle = viewModel::toggleDynamicColor,
-                    onClose = { scope.launch { drawerState.close() } },
-                )
-            },
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background,
         ) {
-            Scaffold(
-                topBar = {
-                    TopAppBar(
-                        title = { },
-                        navigationIcon = {
-                            if (canNavigateBack) {
-                                IconButton(onClick = { navController.popBackStack() }) {
-                                    Icon(
-                                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                        contentDescription = stringResource(Res.string.cd_navigate_back),
-                                    )
-                                }
-                            }
-                        },
-                        actions = {
-                            IconButton(onClick = { scope.launch { drawerState.open() } }) {
-                                Icon(
-                                    imageVector = Icons.Filled.Tune,
-                                    contentDescription = stringResource(Res.string.cd_open_settings),
+            CompositionLocalProvider(LocalInteractiveSurfaceCallbacks provides interactionCallbacks) {
+                BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                    val useWideLayout = maxWidth >= WideLayoutBreakpoint
+
+                    LaunchedEffect(useWideLayout) {
+                        if (useWideLayout && drawerState.currentValue == DrawerValue.Open) {
+                            drawerState.close()
+                        }
+                    }
+
+                    if (useWideLayout) {
+                        Row(modifier = Modifier.fillMaxSize()) {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .width(SettingsRailWidth)
+                                        .fillMaxHeight(),
+                            ) {
+                                SettingsDrawerContent(
+                                    themeState = themeState,
+                                    onThemeSelected = viewModel::onThemeSelected,
+                                    onDarkModeToggle = viewModel::toggleDarkMode,
+                                    onDynamicToggle = viewModel::toggleDynamicColor,
+                                    onClose = {},
+                                    showCloseButton = false,
                                 )
                             }
-                        },
-                    )
-                },
-            ) { innerPadding ->
-                Navigation(
-                    navController = navController,
-                    menuState = menuState,
-                    onSubmenuSelected = viewModel::onSubmenuSelected,
-                    modifier = Modifier.padding(innerPadding),
-                )
+
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .width(1.dp)
+                                        .fillMaxHeight()
+                                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.7f)),
+                            )
+
+                            MainScaffold(
+                                canNavigateBack = canNavigateBack,
+                                showSettingsButton = false,
+                                onNavigateBack = { navController.popBackStack() },
+                                onOpenSettings = {},
+                                content = { innerPadding ->
+                                    Navigation(
+                                        navController = navController,
+                                        menuState = menuState,
+                                        onSubmenuSelected = viewModel::onSubmenuSelected,
+                                        modifier = Modifier.padding(innerPadding),
+                                    )
+                                },
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                    } else {
+                        val canOpenFromEdge =
+                            drawerState.currentValue == DrawerValue.Closed && activeInteractiveSurfaces == 0
+
+                        ModalNavigationDrawer(
+                            drawerState = drawerState,
+                            gesturesEnabled = false,
+                            drawerContent = {
+                                SettingsDrawerContent(
+                                    themeState = themeState,
+                                    onThemeSelected = viewModel::onThemeSelected,
+                                    onDarkModeToggle = viewModel::toggleDarkMode,
+                                    onDynamicToggle = viewModel::toggleDynamicColor,
+                                    onClose = { scope.launch { drawerState.close() } },
+                                )
+                            },
+                        ) {
+                            Box(modifier = Modifier.fillMaxSize()) {
+                                MainScaffold(
+                                    canNavigateBack = canNavigateBack,
+                                    showSettingsButton = true,
+                                    onNavigateBack = { navController.popBackStack() },
+                                    onOpenSettings = {
+                                        scope.launch {
+                                            drawerState.open()
+                                        }
+                                    },
+                                    content = { innerPadding ->
+                                        Navigation(
+                                            navController = navController,
+                                            menuState = menuState,
+                                            onSubmenuSelected = viewModel::onSubmenuSelected,
+                                            modifier = Modifier.padding(innerPadding),
+                                        )
+                                    },
+                                )
+
+                                SettingsEdgeSwipeOpenZone(
+                                    visible = canOpenFromEdge,
+                                    onOpen = {
+                                        scope.launch {
+                                            drawerState.open()
+                                        }
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -104,6 +200,90 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
             navController.navigate(it.route)
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MainScaffold(
+    canNavigateBack: Boolean,
+    showSettingsButton: Boolean,
+    onNavigateBack: () -> Unit,
+    onOpenSettings: () -> Unit,
+    content: @Composable (innerPadding: androidx.compose.foundation.layout.PaddingValues) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { },
+                navigationIcon = {
+                    if (canNavigateBack) {
+                        IconButton(onClick = onNavigateBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = stringResource(Res.string.cd_navigate_back),
+                            )
+                        }
+                    }
+                },
+                actions = {
+                    if (showSettingsButton) {
+                        IconButton(onClick = onOpenSettings) {
+                            Icon(
+                                imageVector = Icons.Filled.Tune,
+                                contentDescription = stringResource(Res.string.cd_open_settings),
+                            )
+                        }
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        content(innerPadding)
+    }
+}
+
+@Composable
+private fun BoxScope.SettingsEdgeSwipeOpenZone(
+    visible: Boolean,
+    onOpen: () -> Unit,
+) {
+    if (!visible) return
+
+    val dragThresholdPx = with(LocalDensity.current) { SettingsEdgeOpenDragThreshold.toPx() }
+
+    Box(
+        modifier =
+            Modifier
+                .align(Alignment.CenterStart)
+                .fillMaxHeight()
+                .width(SettingsEdgeOpenZoneWidth)
+                .pointerInput(onOpen) {
+                    var consumedDistance = 0f
+                    detectHorizontalDragGestures(
+                        onDragStart = {
+                            consumedDistance = 0f
+                        },
+                        onHorizontalDrag = { change, dragAmount ->
+                            if (dragAmount <= 0f) return@detectHorizontalDragGestures
+
+                            consumedDistance += dragAmount
+                            if (consumedDistance >= dragThresholdPx) {
+                                change.consume()
+                                consumedDistance = 0f
+                                onOpen()
+                            }
+                        },
+                        onDragEnd = {
+                            consumedDistance = 0f
+                        },
+                        onDragCancel = {
+                            consumedDistance = 0f
+                        },
+                    )
+                },
+    )
 }
 
 @Composable

--- a/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/SettingsDrawer.kt
+++ b/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/SettingsDrawer.kt
@@ -73,6 +73,7 @@ fun SettingsDrawerContent(
     onDarkModeToggle: () -> Unit,
     onDynamicToggle: () -> Unit,
     onClose: () -> Unit,
+    showCloseButton: Boolean = true,
 ) {
     val hasDynamicColors = LocalHasDynamicColorFeature.current
     val githubUrl = stringResource(Res.string.github_url)
@@ -91,7 +92,10 @@ fun SettingsDrawerContent(
         drawerShape = RoundedCornerShape(topEnd = 28.dp, bottomEnd = 28.dp),
         modifier = Modifier.width(320.dp),
     ) {
-        DrawerHeader(onClose = onClose)
+        DrawerHeader(
+            onClose = onClose,
+            showCloseButton = showCloseButton,
+        )
 
         DrawerSectionTitle(text = stringResource(Res.string.drawer_section_appearance))
         DrawerSettingCard(
@@ -152,7 +156,10 @@ fun SettingsDrawerContent(
 }
 
 @Composable
-private fun DrawerHeader(onClose: () -> Unit) {
+private fun DrawerHeader(
+    onClose: () -> Unit,
+    showCloseButton: Boolean,
+) {
     val headerBrush =
         Brush.horizontalGradient(
             listOf(
@@ -184,12 +191,16 @@ private fun DrawerHeader(onClose: () -> Unit) {
                     color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f),
                 )
             }
-            IconButton(onClick = onClose) {
-                Icon(
-                    imageVector = Icons.Filled.Close,
-                    contentDescription = stringResource(Res.string.cd_close_settings),
-                    tint = MaterialTheme.colorScheme.onPrimary,
-                )
+            if (showCloseButton) {
+                IconButton(onClick = onClose) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = stringResource(Res.string.cd_close_settings),
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                    )
+                }
+            } else {
+                Spacer(modifier = Modifier.size(40.dp))
             }
         }
     }

--- a/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/demo/pie/PieChartDemo.kt
+++ b/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/demo/pie/PieChartDemo.kt
@@ -37,9 +37,8 @@ object PieChartDemoStyle {
 
     @Composable
     fun custom(pieColors: List<Color>): PieChartStyle {
-        val chartColors = LocalChartColors.current
         return PieChartDefaults.style(
-            borderColor = chartColors.tooltipOnSurface,
+            borderColor = MaterialTheme.colorScheme.surface,
             donutPercentage = 40f,
             borderWidth = 5f,
             pieColors = pieColors,

--- a/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/ui/composable/InteractiveSurfaceLock.kt
+++ b/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/ui/composable/InteractiveSurfaceLock.kt
@@ -1,0 +1,73 @@
+package io.github.dautovicharis.charts.app.ui.composable
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+
+@Stable
+data class InteractiveSurfaceCallbacks(
+    val onInteractionStart: () -> Unit = {},
+    val onInteractionEnd: () -> Unit = {},
+)
+
+val LocalInteractiveSurfaceCallbacks =
+    staticCompositionLocalOf { InteractiveSurfaceCallbacks() }
+
+@Composable
+fun DrawerGestureLockContainer(
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    if (!enabled) {
+        Box(modifier = modifier) {
+            content()
+        }
+        return
+    }
+
+    val callbacks = LocalInteractiveSurfaceCallbacks.current
+    var isInteracting by remember { mutableStateOf(false) }
+
+    DisposableEffect(callbacks) {
+        onDispose {
+            if (isInteracting) {
+                callbacks.onInteractionEnd()
+            }
+        }
+    }
+
+    Box(
+        modifier =
+            modifier.pointerInput(callbacks) {
+                awaitPointerEventScope {
+                    var wasPressed = false
+                    while (true) {
+                        val event = awaitPointerEvent(pass = PointerEventPass.Initial)
+                        val isPressed = event.changes.any { it.pressed }
+
+                        if (!wasPressed && isPressed) {
+                            callbacks.onInteractionStart()
+                            isInteracting = true
+                        } else if (wasPressed && !isPressed) {
+                            callbacks.onInteractionEnd()
+                            isInteracting = false
+                        }
+
+                        wasPressed = isPressed
+                    }
+                }
+            },
+    ) {
+        content()
+    }
+}

--- a/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/ui/composable/StyleAndChart.kt
+++ b/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/ui/composable/StyleAndChart.kt
@@ -209,7 +209,9 @@ private fun StyleAndChartChartItem(
         horizontalArrangement = Arrangement.Center,
     ) {
         key(chartItemKey) {
-            chartItem()
+            DrawerGestureLockContainer {
+                chartItem()
+            }
         }
     }
 }

--- a/app/src/jsMain/resources/index.html
+++ b/app/src/jsMain/resources/index.html
@@ -14,10 +14,17 @@
             width: 100%;
             height: 100%;
             overflow: hidden;
+            background: #fcfcfd;
         }
         #Charts {
             width: 100%;
             height: 100%;
+            background: inherit;
+        }
+        @media (prefers-color-scheme: dark) {
+            html, body {
+                background: #09090f;
+            }
         }
     </style>
 </head>

--- a/docs/content/snapshot/wiki/index.md
+++ b/docs/content/snapshot/wiki/index.md
@@ -2,13 +2,25 @@
   <img src="/content/snapshot/wiki/assets/logo.png" alt="Charts Library Logo" style="max-width: 500px;">
 </div>
 
-# Charts 2.0.1-SNAPSHOT
+# Charts 2.0.2-SNAPSHOT
 
 Welcome to the Charts documentation! This library provides a simple way to create beautiful charts in Kotlin Multiplatform applications.
 
 <div style="text-align: center; margin: 2rem 0;">
   <img src="/content/snapshot/wiki/assets/demo.gif" alt="Charts Demo" style="max-width: 100%; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);">
 </div>
+
+## What's New in 2.0.2-SNAPSHOT
+
+### ✨ Features
+- **Radar Chart**: Added a new radar chart component for multivariate data visualization ([#255](https://github.com/dautovicharis/Charts/pull/255))
+- **Chart Gallery**: Added a gallery to explore available chart types and examples ([#256](https://github.com/dautovicharis/Charts/pull/256))
+
+### 🐛 Fixes
+- **Gesture Handling**: Improved touch and scroll interactions to avoid gesture conflicts ([#248](https://github.com/dautovicharis/Charts/pull/248))
+- **Line Chart Dragging**: Fixed drag behavior to keep selected points on the curve ([#247](https://github.com/dautovicharis/Charts/pull/247))
+- **Bar Chart Selection**: Fixed selection calculations related to bar spacing ([#250](https://github.com/dautovicharis/Charts/pull/250))
+- **Chart State Stability**: Improved chart state and data update consistency ([#252](https://github.com/dautovicharis/Charts/pull/252))
 
 ## Getting Started
 
@@ -17,7 +29,3 @@ New to Charts? Check out our [Getting Started Guide](/2.0.1/wiki/getting-started
 ## Documentation
 
 - [API Documentation](/snapshot/api) - Detailed API reference
-
-## What's New in 2.0.2-SNAPSHOT
-
-TODO


### PR DESCRIPTION
## Summary
This PR updates the snapshot documentation page to align with the current 2.0.2-SNAPSHOT messaging and also includes the in-progress app interaction updates currently staged in the workspace, including drawer gesture lock behavior and related UI wiring.

## Changes
- update `docs/content/snapshot/wiki/index.md` with `2.0.2-SNAPSHOT` title and a concrete "What's New" section
- add `InteractiveSurfaceLock` and wire interaction callbacks through the main screen/settings flow
- update app layout and drawer behavior handling, plus associated JS resource changes

## Notes/Risk
- Includes both docs and app changes in one PR because these files were already staged in the current work context.
