### PR TITLE
fix(ci): skip lint and tests for docs-only changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,13 +19,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Detect code changes
+        id: changes
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          SHOULD_RUN="$(bash scripts/ci-has-code-changes.sh "$BASE_SHA" "$HEAD_SHA")"
+          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
       - name: Set up JDK 17
+        if: steps.changes.outputs.should_run == 'true'
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'
           cache: gradle
       - name: Cache Gradle packages
+        if: steps.changes.outputs.should_run == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -35,4 +44,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Lint
+        if: steps.changes.outputs.should_run == 'true'
         run: ./gradlew ktlintCheck --info
+      - name: Skip lint for docs-only changes
+        if: steps.changes.outputs.should_run != 'true'
+        run: echo "No code/build changes detected. Skipping lint."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Detect code changes
+        id: changes
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          SHOULD_RUN="$(bash scripts/ci-has-code-changes.sh "$BASE_SHA" "$HEAD_SHA")"
+          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
       - name: Set up JDK 17
+        if: steps.changes.outputs.should_run == 'true'
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'
           cache: gradle
       - name: Cache Gradle packages
+        if: steps.changes.outputs.should_run == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -35,4 +44,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Test
+        if: steps.changes.outputs.should_run == 'true'
         run: ./gradlew chartsTest --info
+      - name: Skip tests for docs-only changes
+        if: steps.changes.outputs.should_run != 'true'
+        run: echo "No code/build changes detected. Skipping tests."

--- a/scripts/ci-has-code-changes.sh
+++ b/scripts/ci-has-code-changes.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CODE_PATH_PATTERN='^(charts/|app/|androidApp/|iosApp/|buildSrc/|gradle/|build\.gradle\.kts$|settings\.gradle\.kts$|gradle\.properties$|gradlew$|gradlew\.bat$|\.editorconfig$|\.github/workflows/)'
+
+is_code_change() {
+  local changed_files="$1"
+
+  if grep -Eq "$CODE_PATH_PATTERN" <<<"$changed_files"; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+collect_changed_files() {
+  local base_sha="$1"
+  local head_sha="$2"
+  git diff --name-only "${base_sha}...${head_sha}"
+}
+
+assert_equal() {
+  local expected="$1"
+  local actual="$2"
+  local name="$3"
+
+  if [[ "$expected" != "$actual" ]]; then
+    echo "FAIL: $name (expected '$expected', got '$actual')" >&2
+    return 1
+  fi
+
+  echo "PASS: $name"
+}
+
+run_self_test() {
+  local failures=0
+  local result
+
+  result="$(is_code_change $'README.md\ndocs/README.md\n.agent/docs-update.md')"
+  if ! assert_equal "false" "$result" "docs-only changes"; then
+    failures=$((failures + 1))
+  fi
+
+  result="$(is_code_change $'README.md\ncharts/src/commonMain/kotlin/Foo.kt')"
+  if ! assert_equal "true" "$result" "charts source change"; then
+    failures=$((failures + 1))
+  fi
+
+  result="$(is_code_change "build.gradle.kts")"
+  if ! assert_equal "true" "$result" "root gradle file"; then
+    failures=$((failures + 1))
+  fi
+
+  result="$(is_code_change ".github/workflows/test.yml")"
+  if ! assert_equal "true" "$result" "workflow change"; then
+    failures=$((failures + 1))
+  fi
+
+  result="$(is_code_change "charts2/src/Main.kt")"
+  if ! assert_equal "false" "$result" "prefix boundary"; then
+    failures=$((failures + 1))
+  fi
+
+  if [[ "$failures" -gt 0 ]]; then
+    echo "Self-test failed: $failures case(s)." >&2
+    return 1
+  fi
+
+  echo "All self-tests passed."
+}
+
+main() {
+  if [[ "${1:-}" == "--self-test" ]]; then
+    run_self_test
+    return
+  fi
+
+  local base_sha="${1:?base sha is required}"
+  local head_sha="${2:?head sha is required}"
+  local changed_files
+
+  changed_files="$(collect_changed_files "$base_sha" "$head_sha")"
+  is_code_change "$changed_files"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
This PR updates CI so lint and test workflows skip expensive Gradle jobs when a pull request only changes documentation or agent instruction files, while still running normally for code, build, and workflow changes.

## Changes
- Added `scripts/ci-has-code-changes.sh` to centralize CI change detection logic.
- Switched change detection to a three-dot diff (`base...head`) for PR-accurate file matching.
- Updated `.github/workflows/lint.yml` to run setup/lint only when relevant files changed.
- Updated `.github/workflows/test.yml` to run setup/tests only when relevant files changed.
- Added built-in script self-tests (`--self-test`) covering docs-only, code, root Gradle, workflow, and prefix-boundary cases.

## Notes/Risk
- None
