### PR TITLE
docs(snapshot): prepare 2.2.0-SNAPSHOT docs

### DIFF
--- a/buildSrc/src/main/kotlin/io/github/dautovicharis/charts/Config.kt
+++ b/buildSrc/src/main/kotlin/io/github/dautovicharis/charts/Config.kt
@@ -14,6 +14,6 @@ object Config {
     const val demoVersionCode = 4
 
     // Charts library
-    const val chartsVersion = "2.1.0"
+    const val chartsVersion = "2.2.0-SNAPSHOT"
     const val chartsNamespace = "$groupId.$artifactId"
 }

--- a/docs/content/snapshot/wiki/index.md
+++ b/docs/content/snapshot/wiki/index.md
@@ -2,14 +2,14 @@
   <img src="/content/snapshot/wiki/assets/logo.png" alt="Charts Library Logo" style="max-width: 500px;">
 </div>
 
-# Charts SNAPSHOT
+# Charts 2.2.0-SNAPSHOT
 
 <div style="text-align: center; margin: 2rem 0;">
   <img src="/content/snapshot/wiki/assets/demo.png" alt="Charts Demo" style="max-width: 100%; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);">
 </div>
 
 
-## What's New in SNAPSHOT
+## What's New in 2.2.0-SNAPSHOT
 
 
 ## Getting Started

--- a/docs/registry/versions.json
+++ b/docs/registry/versions.json
@@ -6,7 +6,7 @@
       "wikiRoot": "/docs/content/snapshot/wiki",
       "apiBase": "/docs/static/api/snapshot",
       "demoBase": "/docs/static/demo/snapshot",
-      "releasedAt": "2026-02-06",
+      "releasedAt": "2026-02-09",
       "notes": "Latest development snapshot"
     },
     {


### PR DESCRIPTION
## Summary
Prepare the next development snapshot line by targeting `2.2.0-SNAPSHOT`, refreshing snapshot wiki headers, and updating the snapshot registry metadata/date. Regenerate docs and publish updated static assets to `upstream/docs-static`.

## Changes
- bump `chartsVersion` to `2.2.0-SNAPSHOT` in `Config.kt`
- update snapshot wiki title and "What's New" header to `2.2.0-SNAPSHOT`
- refresh snapshot `releasedAt` in `docs/registry/versions.json`
- run `./gradlew generateDocs`
- publish docs static assets to `upstream/docs-static`

## Notes/Risk
- None
