### PR TITLE
ci: reuse CHARTS_WORKFLOW_TOKEN for docs promotion [skip ci]

### DIFF
--- a/.github/workflows/promote-docs.yml
+++ b/.github/workflows/promote-docs.yml
@@ -60,11 +60,11 @@ jobs:
       - name: Validate charts-docs workflow token
         shell: bash
         env:
-          CHARTS_DOCS_WORKFLOW_TOKEN: ${{ secrets.CHARTS_DOCS_WORKFLOW_TOKEN }}
+          CHARTS_WORKFLOW_TOKEN: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
         run: |
           set -euo pipefail
-          if [[ -z "${CHARTS_DOCS_WORKFLOW_TOKEN:-}" ]]; then
-            echo "Missing required secret: CHARTS_DOCS_WORKFLOW_TOKEN." >&2
+          if [[ -z "${CHARTS_WORKFLOW_TOKEN:-}" ]]; then
+            echo "Missing required secret: CHARTS_WORKFLOW_TOKEN." >&2
             echo "Cross-repo workflow dispatch to HDCharts/charts-docs cannot use GITHUB_TOKEN." >&2
             exit 1
           fi
@@ -76,7 +76,7 @@ jobs:
           DOCS_REPO_REF: ${{ github.event.inputs.docs_repo_ref }}
           RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
         with:
-          github-token: ${{ secrets.CHARTS_DOCS_WORKFLOW_TOKEN }}
+          github-token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
           script: |
             const releaseVersion = process.env.RELEASE_VERSION;
             const docsRepoRef = process.env.DOCS_REPO_REF || 'main';

--- a/docs/release/docs-promotion.md
+++ b/docs/release/docs-promotion.md
@@ -5,7 +5,7 @@ Workflow: `charts/.github/workflows/promote-docs.yml`
 ```mermaid
 flowchart TD
   A["workflow_dispatch: charts: promote-docs.yml"] --> B["axion: resolve-release-version.sh"]
-  B --> C{"CHARTS_DOCS_WORKFLOW_TOKEN set?"}
+  B --> C{"CHARTS_WORKFLOW_TOKEN set?"}
   C -- No --> CX["Fail"]
   C -- Yes --> E["charts-docs: promote-docs.yml (workflow_dispatch)"]
   E --> F["promote-snapshot-to-release.sh"]


### PR DESCRIPTION
## Why
The `promote-docs.yml` workflow referenced a secret `CHARTS_DOCS_WORKFLOW_TOKEN` that does not exist, causing cross-repo dispatch to `HDCharts/charts-docs` to fail.

## Summary
Replace all references to `CHARTS_DOCS_WORKFLOW_TOKEN` with the existing `CHARTS_WORKFLOW_TOKEN`, which already has the correct permissions across all HDCharts repos. This eliminates the need for a separate docs-specific token.

## Changes
- `promote-docs.yml`: renamed secret reference in env mapping, validation check, and `github-token` input (3 occurrences)
- `docs/release/docs-promotion.md`: updated Mermaid flowchart to reflect the renamed secret

## Release/Changeset
- Not required (technical/internal-only)

## Notes/Risk
- None