### PR TITLE
ci: fix workflow token secret name typo

### DIFF
--- a/.github/workflows/set-api-baseline.yml
+++ b/.github/workflows/set-api-baseline.yml
@@ -84,11 +84,11 @@ jobs:
       - name: Validate workflow update token
         shell: bash
         env:
-          CHARTS_WORFLOW_TOKEN: ${{ secrets.CHARTS_WORFLOW_TOKEN }}
+          CHARTS_WORKFLOW_TOKEN: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
         run: |
           set -euo pipefail
-          if [[ -z "${CHARTS_WORFLOW_TOKEN:-}" ]]; then
-            echo "Missing required secret: CHARTS_WORFLOW_TOKEN." >&2
+          if [[ -z "${CHARTS_WORKFLOW_TOKEN:-}" ]]; then
+            echo "Missing required secret: CHARTS_WORKFLOW_TOKEN." >&2
             echo "Creating PRs from this workflow requires a token with workflow write scope." >&2
             exit 1
           fi
@@ -97,7 +97,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.CHARTS_WORFLOW_TOKEN }}
+          token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
           commit-message: "ci(api): update API compatibility baseline [skip ci]"
           branch: "ci/update-api-compatibility-baseline"
           delete-branch: true

--- a/.github/workflows/sync-version-file.yml
+++ b/.github/workflows/sync-version-file.yml
@@ -123,11 +123,11 @@ jobs:
       - name: Validate workflow update token
         shell: bash
         env:
-          CHARTS_WORFLOW_TOKEN: ${{ secrets.CHARTS_WORFLOW_TOKEN }}
+          CHARTS_WORKFLOW_TOKEN: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
         run: |
           set -euo pipefail
-          if [[ -z "${CHARTS_WORFLOW_TOKEN:-}" ]]; then
-            echo "Missing required secret: CHARTS_WORFLOW_TOKEN." >&2
+          if [[ -z "${CHARTS_WORKFLOW_TOKEN:-}" ]]; then
+            echo "Missing required secret: CHARTS_WORKFLOW_TOKEN." >&2
             echo "Syncing workflow files requires a token with workflow write scope." >&2
             exit 1
           fi
@@ -135,7 +135,7 @@ jobs:
       - name: Create PR when .version changed
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.CHARTS_WORFLOW_TOKEN }}
+          token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
           add-paths: ${{ steps.version.outputs.sync_paths }}
           branch: chore/sync-version-file
           delete-branch: true


### PR DESCRIPTION
## Summary
- fix typo in workflow secret name from CHARTS_WORFLOW_TOKEN to CHARTS_WORKFLOW_TOKEN
- update both sync-version and api-baseline workflows to use the same secret

## Why
Recent runs failed because the typoed secret name resolves to empty, while the configured org secret is CHARTS_WORKFLOW_TOKEN.

## Validation
- searched workflow files to confirm no remaining WORFLOW references