### PR TITLE
chore: bump AGP 9.3.0 and Gradle 9.5.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Contributions are welcome.
 There are many ways to contribute, including feature work, bug fixes, performance improvements, test coverage, docs updates, and tooling/CI refinements.
 
 ## Requirements
-- Android Studio Panda 2 | 2025.3.2
+- Android Studio Quail 2 | 2026.1.2
 
 ## Project hierarchy
 <pre>

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,3 +36,6 @@ signAllPublications=true
 # - snapshot: resolve io.github.dautovicharis snapshot artifacts only (requires chartsPublishedVersion ending with -SNAPSHOT).
 # chartsDependencyMode=local
 # chartsPublishedVersion=2.3.0-SNAPSHOT
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 java = "17"
 
 # Android gradle plugin version
-agp = "9.1.0"
+agp = "9.3.0"
 
 androidx-navigation = "2.9.2"
 androidx-lifecycle = "2.10.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Bump Android Gradle Plugin 9.1.0 → 9.3.0 and Gradle wrapper 9.4.0 → 9.5.0.
- Enable `org.gradle.tooling.parallel` for faster sync and update Android Studio reference in CONTRIBUTING.md.