### PR TITLE
chore: sync release notes workflow

### DIFF
--- a/.github/workflows/promote-docs.yml
+++ b/.github/workflows/promote-docs.yml
@@ -13,15 +13,6 @@ on:
           - "2.3.0"
         default: "2.3.0"
       # VERSION_INPUT_END
-      docs_repo_ref:
-        description: "charts-docs ref to dispatch promote workflow on"
-        required: false
-        default: main
-        type: string
-      release_notes:
-        description: "Optional registry notes for charts-docs entry"
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -34,7 +25,9 @@ jobs:
   promote-docs:
     name: Resolve version and dispatch charts-docs promotion
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'HDCharts' }}
+    if: >
+      github.repository_owner == 'HDCharts' &&
+      github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -73,26 +66,20 @@ jobs:
         uses: actions/github-script@v7
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
-          DOCS_REPO_REF: ${{ github.event.inputs.docs_repo_ref }}
-          RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
         with:
           github-token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
           script: |
             const releaseVersion = process.env.RELEASE_VERSION;
-            const docsRepoRef = process.env.DOCS_REPO_REF || 'main';
-            const releaseNotes = process.env.RELEASE_NOTES || '';
             const sourceRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.actions.createWorkflowDispatch({
+            await github.rest.repos.createDispatchEvent({
               owner: 'HDCharts',
               repo: 'charts-docs',
-              workflow_id: 'promote-docs.yml',
-              ref: docsRepoRef,
-              inputs: {
+              event_type: 'promote-docs',
+              client_payload: {
                 release_version: releaseVersion,
-                release_notes: releaseNotes,
                 source_repository: `${context.repo.owner}/${context.repo.repo}`,
                 source_sha: context.sha,
                 source_run_url: sourceRunUrl,
               },
             });
-            core.info(`Dispatched charts-docs promote-docs.yml for ${releaseVersion} on ref ${docsRepoRef}`);
+            core.info(`Dispatched charts-docs promotion for ${releaseVersion}`);

--- a/.github/workflows/sync-release-notes.yml
+++ b/.github/workflows/sync-release-notes.yml
@@ -1,0 +1,101 @@
+name: Sync Release Notes
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "release-notes/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-release-notes-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch-sync:
+    name: Dispatch charts-docs release-note sync
+    runs-on: ubuntu-latest
+    if: >
+      github.repository_owner == 'HDCharts' &&
+      github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout charts
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release-note source
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          charts_version="$(awk 'NF {gsub(/\r/, "", $0); print $0; exit}' .version)"
+          release_version="${charts_version%-SNAPSHOT}"
+
+          if [[ ! "${release_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Expected .version to contain a SemVer snapshot, got: ${charts_version}" >&2
+            exit 1
+          fi
+
+          source_dir="release-notes/${release_version}"
+          if [[ ! -d "${source_dir}" ]]; then
+            echo "Missing release-note source directory: ${source_dir}." >&2
+            exit 1
+          fi
+
+          echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"
+          echo "source_ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate charts-docs workflow token
+        shell: bash
+        env:
+          CHARTS_WORKFLOW_TOKEN: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CHARTS_WORKFLOW_TOKEN:-}" ]]; then
+            echo "Missing required secret: CHARTS_WORKFLOW_TOKEN." >&2
+            echo "Cross-repository workflow dispatch cannot use GITHUB_TOKEN." >&2
+            exit 1
+          fi
+
+      - name: Dispatch charts-docs sync workflow
+        uses: actions/github-script@v7
+        env:
+          RELEASE_VERSION: ${{ steps.source.outputs.release_version }}
+          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
+        with:
+          github-token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
+          script: |
+            const sourceRunUrl =
+              `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            await github.rest.repos.createDispatchEvent({
+              owner: 'HDCharts',
+              repo: 'charts-docs',
+              event_type: 'sync-release-notes',
+              client_payload: {
+                release_version: process.env.RELEASE_VERSION,
+                source_ref: process.env.SOURCE_REF,
+                source_repository: `${context.repo.owner}/${context.repo.repo}`,
+                source_run_url: sourceRunUrl,
+              },
+            });
+
+            core.info(
+              `Dispatched charts-docs release-note sync for ${process.env.RELEASE_VERSION} ` +
+              `from ${process.env.SOURCE_REF}`,
+            );
+
+      - name: Publish dispatch summary
+        shell: bash
+        run: |
+          {
+            echo "## Release-note sync dispatched"
+            echo "- release: \`${{ steps.source.outputs.release_version }}\`"
+            echo "- charts source: \`${{ steps.source.outputs.source_ref }}\`"
+            echo "- charts-docs receiver: default branch"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -8,3 +8,5 @@ This directory contains release workflow diagrams split by flow.
 - [Docs Release Publish](./docs-release-publish.md)
 - [Docs Snapshot Publish](./docs-snapshot-publish.md)
 - [Docs Promotion (Cross-Repo)](./docs-promotion.md)
+- [Release Notes Sync](./release-notes-sync.md)
+- [Release Checklist](./release-checklist.md)

--- a/docs/release/charts-release.md
+++ b/docs/release/charts-release.md
@@ -20,3 +20,8 @@ flowchart TD
   L --> M["Gradle (Axion): pushRelease (tag push)"]
   M --> N["Commit comment (success)"]
 ```
+
+Before running this workflow, complete the
+[Release Checklist](./release-checklist.md). In particular, the docs promotion
+pull request must be merged because this workflow requires the release version
+in the charts-docs registry.

--- a/docs/release/docs-promotion.md
+++ b/docs/release/docs-promotion.md
@@ -7,14 +7,19 @@ flowchart TD
   A["workflow_dispatch: charts: promote-docs.yml"] --> B["axion: resolve-release-version.sh"]
   B --> C{"CHARTS_WORKFLOW_TOKEN set?"}
   C -- No --> CX["Fail"]
-  C -- Yes --> E["charts-docs: promote-docs.yml (workflow_dispatch)"]
+  C -- Yes --> E["charts-docs: promote-docs.yml (repository_dispatch)"]
   E --> F["promote-snapshot-to-release.sh"]
-  F --> G["reset-snapshot-content.sh"]
-  G --> H["test-docs-release-links-contract.sh"]
-  H --> I["Build docs app (DOCS_STATIC_BASE_URL required)"]
-  I --> J["Create PR with promoted docs changes"]
+  F --> H["test-docs-release-links-contract.sh"]
+  H --> I["Create PR with promoted docs changes"]
+  I --> J["charts-docs PR CI builds and validates docs"]
 ```
 
 Notes:
 - `promote-snapshot-to-release.sh`: copies `content/snapshot` to `content/{release_version}` and updates registry.
-- `reset-snapshot-content.sh`: clears snapshot changes and resets breaking-changes baseline.
+- The release version is resolved automatically by the charts workflow. The
+  registry description is generated as `Release {release_version}`; promotion
+  has no editable version or description input.
+- Versioned release notes remain under `release-notes/{release_version}` and
+  are not copied or reset during promotion.
+- The charts-docs workflow is an internal receiver on the default branch and
+  cannot be started from the Actions manual-run form.

--- a/docs/release/high-level-map.md
+++ b/docs/release/high-level-map.md
@@ -8,13 +8,17 @@ flowchart LR
     C["publish-docs-release.yml (Docs Release -> S3)"]
     D["publish-docs-snapshot.yml (Docs Snapshot -> S3)"]
     E["promote-docs.yml (Dispatch to charts-docs)"]
+    H["sync-release-notes.yml (Dispatch release-note sync)"]
   end
 
   subgraph CHARTS_DOCS["charts-docs repo"]
     F["promote-docs.yml (Promote snapshot content -> release PR)"]
     G["docs-ci.yml (Contract + docs build checks)"]
+    I["sync-release-notes.yml (Mirror versioned notes -> PR)"]
   end
 
   E --> F
   F --> G
+  H --> I
+  I --> G
 ```

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -1,0 +1,20 @@
+# Release Checklist
+
+Use the operator-facing workflows in `HDCharts/charts`. The charts-docs
+promotion and release-note workflows are internal receivers and are not run
+manually.
+
+1. Merge all charts changes intended for the release.
+2. Merge the latest automated charts-docs release-note sync pull request.
+3. Run `Promote Docs` from the charts `main` branch.
+4. Review and merge the generated charts-docs promotion pull request.
+5. Run `Release` from the charts `main` branch.
+6. Run `Docs Release Publish` after the charts release succeeds.
+
+`Promote Docs` resolves the release version automatically, freezes
+`content/snapshot` as `content/<version>`, and registers the version. The charts
+release and docs release-publish workflows intentionally fail when that
+registry entry is missing.
+
+Release-note directories are already versioned and are not moved or reset
+during promotion.

--- a/docs/release/release-notes-sync.md
+++ b/docs/release/release-notes-sync.md
@@ -1,0 +1,34 @@
+# Release Notes Sync
+
+Workflows:
+
+- `charts/.github/workflows/sync-release-notes.yml`
+- `charts-docs/.github/workflows/sync-release-notes.yml`
+
+```mermaid
+flowchart TD
+  A["Merge release-notes changes to charts main"] --> B["charts: Sync Release Notes"]
+  B --> C["Resolve target release from .version"]
+  C --> D["Dispatch charts-docs with charts commit SHA"]
+  D --> E["Checkout charts at the exact source SHA"]
+  E --> F["Mirror release-notes/version and update current pointer"]
+  F --> G["Validate docs contracts"]
+  G --> H["Create or update charts-docs sync PR"]
+```
+
+The charts workflow runs automatically when `release-notes/**` changes on
+`main`. Run it manually after workflow maintenance, after recovering from a
+failed dispatch, or when charts-docs needs to be reconciled with the current
+charts source without changing a release-note file.
+
+The charts-docs workflow is an internal `repository_dispatch` receiver on its
+default branch. Manual retries and reconciliation always start from the charts
+workflow.
+
+Before promoting snapshot docs to a release, merge the latest release-note sync
+pull request so the released docs can resolve every merged charts change.
+
+The docs app reads the mirrored fragments directly. Snapshot pages follow the
+current-version pointer until that version appears in the release registry;
+released pages use their matching version directory. Promotion does not copy or
+reset release-note files.

--- a/release-notes/2.3.0/changes/363-api-compatibility-checks.md
+++ b/release-notes/2.3.0/changes/363-api-compatibility-checks.md
@@ -1,0 +1,6 @@
+# PR Changeset
+
+- type: `feature`
+- module: `charts-core`
+- pr: `https://github.com/HDCharts/charts/pull/363`
+- release_note: `Added automated API compatibility checks to help prevent accidental breaking changes in future releases.`

--- a/release-notes/2.3.0/changes/365-release-compatibility-migration-docs.md
+++ b/release-notes/2.3.0/changes/365-release-compatibility-migration-docs.md
@@ -1,0 +1,6 @@
+# PR Changeset
+
+- type: `feature`
+- module: `charts`
+- pr: `https://github.com/HDCharts/charts/pull/365`
+- release_note: `Docs now include a migration guide and clearer release highlights.`

--- a/release-notes/2.3.0/changes/394-chart-aspect-ratio-toggle.md
+++ b/release-notes/2.3.0/changes/394-chart-aspect-ratio-toggle.md
@@ -1,0 +1,6 @@
+# PR Changeset
+
+- type: `feature`
+- module: `charts`
+- pr: `https://github.com/HDCharts/charts/pull/394`
+- release_note: `You can now switch chart demos between square, wide, and tall aspect ratios.`

--- a/release-notes/2.3.0/changes/395-improve-style-details-view.md
+++ b/release-notes/2.3.0/changes/395-improve-style-details-view.md
@@ -1,0 +1,6 @@
+# PR Changeset
+
+- type: `feature`
+- module: `charts`
+- pr: `https://github.com/HDCharts/charts/pull/395`
+- release_note: `Style details now group modified/default/unused values and show clearer color and auto-generated property explanations.`

--- a/release-notes/2.3.0/changes/406-bar-chart-per-bar-colors.md
+++ b/release-notes/2.3.0/changes/406-bar-chart-per-bar-colors.md
@@ -1,0 +1,6 @@
+# PR Changeset
+
+- type: `feature`
+- module: `charts-bar`
+- pr: `https://github.com/HDCharts/charts/pull/406`
+- release_note: `Bar charts now support per-bar colors with correct coloring in dense mode.`

--- a/release-notes/2.3.0/changes/411-line-chart-drag-point-default-color.md
+++ b/release-notes/2.3.0/changes/411-line-chart-drag-point-default-color.md
@@ -1,0 +1,6 @@
+# PR Changeset
+
+- type: `fix`
+- module: `charts-line`
+- pr: `https://github.com/HDCharts/charts/pull/411`
+- release_note: `Fixes line chart drag-point default color handling and improves custom preview point visibility.`

--- a/release-notes/2.3.0/changes/413-add-histogram-chart.md
+++ b/release-notes/2.3.0/changes/413-add-histogram-chart.md
@@ -1,0 +1,6 @@
+# PR Changeset
+
+- type: `feature`
+- module: `charts-histogram`
+- pr: `https://github.com/HDCharts/charts/pull/413`
+- release_note: `Add a new histogram chart with customizable styling, selection, and demos across app, docs, and playground.`

--- a/release-notes/2.3.0/changes/443-release-notes-sync.md
+++ b/release-notes/2.3.0/changes/443-release-notes-sync.md
@@ -1,0 +1,6 @@
+# PR Changeset
+
+- type: `docs`
+- module: `charts`
+- pr: `https://github.com/HDCharts/charts/pull/443`
+- release_note: `Release notes and migration guidance now sync through the new release workflow.`

--- a/release-notes/2.3.0/migrations/394-chart-aspect-ratio-toggle.md
+++ b/release-notes/2.3.0/migrations/394-chart-aspect-ratio-toggle.md
@@ -1,0 +1,52 @@
+## charts-core
+
+### Do I need to update call sites?
+
+- No, if you already call `ChartViewDefaults.style(...)` and keep the default square chart area.
+- Yes, if you want a non-square chart area; pass the new `modifierChart` argument.
+
+### What changed
+
+- `ChartViewDefaults.style(...)` now includes `modifierChart: Modifier` (default `Modifier.aspectRatio(1f)`) and threads it through `ChartViewStyle`.
+
+### Migration (only if required)
+
+```kotlin
+// Before
+val chartViewStyle = ChartViewDefaults.style()
+
+// After
+val chartViewStyle = ChartViewDefaults.style(
+    modifierChart = Modifier.aspectRatio(16f / 9f),
+)
+```
+
+- Recommended: Prefer named arguments when calling style factory functions.
+
+## charts-pie
+
+### Do I need to update call sites?
+
+- No, if you never passed `innerPadding` to `PieChartDefaults.style(...)`.
+- Yes, if you previously passed `innerPadding`; move that value into `chartViewStyle`.
+
+### What changed
+
+- `PieChartDefaults.style(...)` removed `innerPadding`.
+- Pie content padding now comes from `chartViewStyle.innerPadding`.
+
+### Migration (only if required)
+
+```kotlin
+// Before
+val pieStyle = PieChartDefaults.style(
+    innerPadding = 24.dp,
+)
+
+// After
+val pieStyle = PieChartDefaults.style(
+    chartViewStyle = ChartViewDefaults.style(innerPadding = 24.dp),
+)
+```
+
+- Recommended: Keep pie container spacing and chart-view spacing aligned through one `ChartViewStyle` instance.

--- a/release-notes/2.3.0/migrations/406-bar-chart-per-bar-colors.md
+++ b/release-notes/2.3.0/migrations/406-bar-chart-per-bar-colors.md
@@ -1,0 +1,31 @@
+## charts-bar
+
+### Do I need to update call sites?
+
+- No, if you call `BarChartDefaults.style(...)` with named arguments only.
+- Yes, if you pass `BarChartDefaults.style(...)` arguments positionally after `barColor`, or if you call internal `validateBarData(...)` directly.
+
+### What changed
+
+- `BarChartDefaults.style(...)` adds `barColors: List<Color> = emptyList()` immediately after `barColor`.
+- `validateBarData(...)` now accepts `colorsSize` to validate `barColors` length against data points.
+
+### Migration (only if required)
+
+```kotlin
+// Before
+val barStyle = BarChartDefaults.style(
+    MaterialTheme.colorScheme.primary,
+    0.4f,
+    10.dp,
+)
+
+// After
+val barStyle = BarChartDefaults.style(
+    barColor = MaterialTheme.colorScheme.primary,
+    barAlpha = 0.4f,
+    space = 10.dp,
+)
+```
+
+- Recommended: Use named arguments for `BarChartDefaults.style(...)` to stay resilient to future parameter additions.

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,0 +1,26 @@
+# Release notes
+
+This directory is the source of truth for user-facing HDCharts release notes.
+Each target release has two fragment directories:
+
+```text
+release-notes/<version>/
+├── changes/
+└── migrations/
+```
+
+- `changes/` contains one short changeset for each user-facing charts pull
+  request.
+- `migrations/` contains one migration fragment for each pull request with
+  breaking API changes.
+
+The target release is the value in `.version` without the `-SNAPSHOT` suffix.
+After changes under `release-notes/` merge to `main`, the
+`Sync Release Notes` workflow dispatches the charts-docs synchronization
+workflow. That workflow mirrors the complete version directory into
+`charts-docs/release-notes/<version>/`, updates its current-version pointer,
+and opens or updates a charts-docs pull request.
+
+Release directories remain in this repository as history. Keeping them
+versioned lets snapshot and released documentation consume the same immutable
+fragments without copying or resetting release-note files during promotion.


### PR DESCRIPTION
## Why

Keep release-note generation and migration guidance aligned with the new release workflow.

## Summary

This updates the charts release workflow and supporting docs so release notes and migrations are generated and mirrored consistently for each release.

## Changes

- Add the release-note sync workflow.
- Refresh release docs for the new promotion flow.
- Add current release-note fragments and migration guidance for 2.3.0.

## Release/Changeset

- Created: `projects/charts/release-notes/2.3.0/changes/443-release-notes-sync.md`

## Notes/Risk

- None

## Related PRs

- `charts-docs`: https://github.com/HDCharts/charts-docs/pull/53
