### PR TITLE
build(deps): bump AGP to 9.3.1 and update SDK versions to 37

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -149,6 +149,7 @@ android {
         }
         getByName("release") {
             isMinifyEnabled = true
+            isShrinkResources = true
             if (hasReleaseSigningConfig) {
                 signingConfig = signingConfigs.getByName("release")
             }

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,9 +1,9 @@
+@Suppress("unused") // Public buildSrc API consumed by the root Gradle build scripts.
 object Config {
     // Common
-    const val COMPILE_SDK = 36
+    const val COMPILE_SDK = 37
     const val MIN_SDK = 24
-    const val TARGET_SDK = 36
-    const val JAVA_VERSION = 17
+    const val TARGET_SDK = 37
     const val GROUP_ID = "io.github.dautovicharis"
     const val ARTIFACT_ID = "charts"
     const val ARTIFACT_CORE_ID = "charts-core"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 java = "17"
 
 # Android gradle plugin version
-agp = "9.3.0"
+agp = "9.3.1"
 
 androidx-navigation = "2.9.2"
 androidx-lifecycle = "2.10.0"


### PR DESCRIPTION
Enable resource shrinking for release builds and update compile/target SDK from 36 to 37.