### PR TITLE
chore(build): remove unsupported iosX64 target

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,6 @@ kotlin {
         }
     }
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64(),
     ).forEach { iosTarget ->

--- a/charts-bar/build.gradle.kts
+++ b/charts-bar/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         }
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/charts-core/build.gradle.kts
+++ b/charts-core/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         }
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/charts-demo-shared/build.gradle.kts
+++ b/charts-demo-shared/build.gradle.kts
@@ -29,7 +29,6 @@ kotlin {
         }
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/charts-histogram/build.gradle.kts
+++ b/charts-histogram/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         }
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/charts-line/build.gradle.kts
+++ b/charts-line/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         }
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/charts-pie/build.gradle.kts
+++ b/charts-pie/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         }
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/charts-radar/build.gradle.kts
+++ b/charts-radar/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         }
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/charts-stacked-area/build.gradle.kts
+++ b/charts-stacked-area/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         }
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/charts-stacked-bar/build.gradle.kts
+++ b/charts-stacked-bar/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         }
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/charts/build.gradle.kts
+++ b/charts/build.gradle.kts
@@ -28,7 +28,6 @@ kotlin {
         }
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 


### PR DESCRIPTION
Remove the iosX64() Kotlin Multiplatform target from all modules as it is no longer supported with the current SDK and AGP versions. Only iosArm64 and iosSimulatorArm64 targets are retained.

BREAKING CHANGE: drop iosX64 simulator target, requiring Apple Silicon (ARM64) for iOS simulator builds