### PR TITLE
chore(ci): extract reusable composite actions and simplify workflows

### DIFF
--- a/.github/actions/prepare-android-signing/action.yml
+++ b/.github/actions/prepare-android-signing/action.yml
@@ -1,0 +1,66 @@
+name: Prepare Android signing
+description: Decode the Android release keystore and export Gradle signing environment variables.
+
+inputs:
+  keystore-base64:
+    required: true
+    description: Base64-encoded Android release keystore.
+  store-password:
+    required: true
+    description: Android release keystore password.
+  key-alias:
+    required: true
+    description: Android release key alias.
+  key-password:
+    required: true
+    description: Android release key password.
+  keystore-path:
+    required: false
+    default: androidApp/release.keystore
+    description: Path where the decoded keystore should be written.
+
+runs:
+  using: composite
+  steps:
+    - name: Decode keystore and export Gradle signing environment
+      shell: bash
+      env:
+        ANDROID_RELEASE_KEYSTORE_BASE64: ${{ inputs.keystore-base64 }}
+        ANDROID_RELEASE_STORE_PASSWORD: ${{ inputs.store-password }}
+        ANDROID_RELEASE_KEY_ALIAS: ${{ inputs.key-alias }}
+        ANDROID_RELEASE_KEY_PASSWORD: ${{ inputs.key-password }}
+        ANDROID_RELEASE_KEYSTORE_PATH: ${{ inputs.keystore-path }}
+      run: |
+        set -euo pipefail
+
+        missing=0
+        for v in ANDROID_RELEASE_KEYSTORE_BASE64 ANDROID_RELEASE_STORE_PASSWORD ANDROID_RELEASE_KEY_ALIAS ANDROID_RELEASE_KEY_PASSWORD; do
+          if [[ -z "${!v:-}" ]]; then
+            echo "Missing secret: ${v}" >&2
+            missing=1
+          fi
+        done
+
+        if [[ "${missing}" -ne 0 ]]; then
+          echo "Android signing cannot proceed because required secrets are missing." >&2
+          exit 1
+        fi
+
+        printf '%s' "${ANDROID_RELEASE_KEYSTORE_BASE64}" | base64 -d > "${ANDROID_RELEASE_KEYSTORE_PATH}"
+        chmod 600 "${ANDROID_RELEASE_KEYSTORE_PATH}"
+
+        write_env() {
+          local name="$1"
+          local value="$2"
+          local delimiter="EOF_$(date +%s%N)_${RANDOM}"
+          {
+            echo "${name}<<${delimiter}"
+            printf '%s\n' "${value}"
+            echo "${delimiter}"
+          } >> "${GITHUB_ENV}"
+        }
+
+        write_env ORG_GRADLE_PROJECT_ANDROID_RELEASE_STORE_FILE "${ANDROID_RELEASE_KEYSTORE_PATH}"
+        write_env ORG_GRADLE_PROJECT_ANDROID_RELEASE_STORE_PASSWORD "${ANDROID_RELEASE_STORE_PASSWORD}"
+        write_env ORG_GRADLE_PROJECT_ANDROID_RELEASE_KEY_ALIAS "${ANDROID_RELEASE_KEY_ALIAS}"
+        write_env ORG_GRADLE_PROJECT_ANDROID_RELEASE_KEY_PASSWORD "${ANDROID_RELEASE_KEY_PASSWORD}"

--- a/.github/actions/prepare-maven-publishing/action.yml
+++ b/.github/actions/prepare-maven-publishing/action.yml
@@ -1,0 +1,63 @@
+name: Prepare Maven publishing
+description: Validate Maven publishing secrets and export Gradle publishing environment variables.
+
+inputs:
+  maven-central-username:
+    required: true
+    description: Maven Central username.
+  maven-central-password:
+    required: true
+    description: Maven Central password.
+  signing-key-id:
+    required: true
+    description: Signing key id.
+  signing-password:
+    required: true
+    description: Signing key password.
+  signing-in-memory-key:
+    required: true
+    description: Signing key material.
+
+runs:
+  using: composite
+  steps:
+    - name: Export Gradle Maven publishing environment
+      shell: bash
+      env:
+        MAVEN_CENTRAL_USERNAME: ${{ inputs.maven-central-username }}
+        MAVEN_CENTRAL_PASSWORD: ${{ inputs.maven-central-password }}
+        SIGNING_KEY_ID: ${{ inputs.signing-key-id }}
+        SIGNING_PASSWORD: ${{ inputs.signing-password }}
+        SIGNING_IN_MEMORY_KEY: ${{ inputs.signing-in-memory-key }}
+      run: |
+        set -euo pipefail
+
+        missing=0
+        for v in MAVEN_CENTRAL_USERNAME MAVEN_CENTRAL_PASSWORD SIGNING_KEY_ID SIGNING_PASSWORD SIGNING_IN_MEMORY_KEY; do
+          if [[ -z "${!v:-}" ]]; then
+            echo "Missing secret: ${v}" >&2
+            missing=1
+          fi
+        done
+
+        if [[ "${missing}" -ne 0 ]]; then
+          echo "Maven publishing cannot proceed because required secrets are missing." >&2
+          exit 1
+        fi
+
+        write_env() {
+          local name="$1"
+          local value="$2"
+          local delimiter="EOF_$(date +%s%N)_${RANDOM}"
+          {
+            echo "${name}<<${delimiter}"
+            printf '%s\n' "${value}"
+            echo "${delimiter}"
+          } >> "${GITHUB_ENV}"
+        }
+
+        write_env ORG_GRADLE_PROJECT_mavenCentralUsername "${MAVEN_CENTRAL_USERNAME}"
+        write_env ORG_GRADLE_PROJECT_mavenCentralPassword "${MAVEN_CENTRAL_PASSWORD}"
+        write_env ORG_GRADLE_PROJECT_signingInMemoryKey "${SIGNING_IN_MEMORY_KEY}"
+        write_env ORG_GRADLE_PROJECT_signingInMemoryKeyId "${SIGNING_KEY_ID}"
+        write_env ORG_GRADLE_PROJECT_signingInMemoryKeyPassword "${SIGNING_PASSWORD}"

--- a/.github/actions/validate-docs-release-version/action.yml
+++ b/.github/actions/validate-docs-release-version/action.yml
@@ -1,0 +1,38 @@
+name: Validate docs release version
+description: Verify that a release version exists in the charts-docs versions registry.
+
+inputs:
+  release-version:
+    required: true
+    description: Release version expected in the charts-docs registry.
+  registry-path:
+    required: false
+    default: charts-docs-repo/registry/versions.json
+    description: Path to charts-docs registry/versions.json.
+
+runs:
+  using: composite
+  steps:
+    - name: Validate release version exists in charts-docs registry
+      shell: bash
+      env:
+        EXPECTED_VERSION: ${{ inputs.release-version }}
+        REGISTRY_PATH: ${{ inputs.registry-path }}
+      run: |
+        set -euo pipefail
+
+        if [[ ! -f "${REGISTRY_PATH}" ]]; then
+          echo "Missing charts-docs registry: ${REGISTRY_PATH}" >&2
+          exit 1
+        fi
+
+        if ! jq -e --arg expected "${EXPECTED_VERSION}" \
+          'any((.versions // [])[]?; .id == $expected)' "${REGISTRY_PATH}" >/dev/null; then
+          available_versions="$(
+            jq -r '[(.versions // [])[]? | .id | select(type == "string" and . != "")] | join(", ")' \
+              "${REGISTRY_PATH}"
+          )"
+          echo "Release version ${EXPECTED_VERSION} is not present in charts-docs registry." >&2
+          echo "Available registry versions: ${available_versions:-"(none)"}" >&2
+          exit 1
+        fi

--- a/.github/actions/validate-docs-static-release/action.yml
+++ b/.github/actions/validate-docs-static-release/action.yml
@@ -1,0 +1,63 @@
+name: Validate docs static release
+description: Verify that versioned docs/static release assets were published to S3.
+
+inputs:
+  release-version:
+    required: true
+    description: Release version expected in docs/static release assets.
+  source-sha:
+    required: true
+    description: Charts commit SHA expected in docs release metadata.
+  docs-static-bucket:
+    required: true
+    description: S3 bucket containing docs/static assets.
+
+runs:
+  using: composite
+  steps:
+    - name: Validate docs static release assets
+      shell: bash
+      env:
+        RELEASE_VERSION: ${{ inputs.release-version }}
+        SOURCE_SHA: ${{ inputs.source-sha }}
+        DOCS_STATIC_BUCKET: ${{ inputs.docs-static-bucket }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "${DOCS_STATIC_BUCKET:-}" ]]; then
+          echo "Missing required repository variable: DOCS_STATIC_BUCKET" >&2
+          exit 1
+        fi
+
+        metadata_file="$(mktemp)"
+        trap 'rm -f "${metadata_file}"' EXIT
+
+        metadata_s3_uri="s3://${DOCS_STATIC_BUCKET}/static/_meta/charts-release-publish.json"
+        if ! aws s3 cp "${metadata_s3_uri}" "${metadata_file}" --only-show-errors; then
+          echo "Missing docs release metadata: ${metadata_s3_uri}" >&2
+          exit 1
+        fi
+
+        metadata_version="$(jq -r '.charts_version // ""' "${metadata_file}")"
+        if [[ "${metadata_version}" != "${RELEASE_VERSION}" ]]; then
+          echo "Docs release metadata version mismatch: expected ${RELEASE_VERSION}, got ${metadata_version:-"(empty)"}." >&2
+          exit 1
+        fi
+
+        metadata_source_sha="$(jq -r '.source_sha // ""' "${metadata_file}")"
+        if [[ "${metadata_source_sha}" != "${SOURCE_SHA}" ]]; then
+          echo "Docs release metadata source mismatch: expected ${SOURCE_SHA}, got ${metadata_source_sha:-"(empty)"}." >&2
+          exit 1
+        fi
+
+        required_keys=(
+          "static/api/${RELEASE_VERSION}/index.html"
+          "static/demo/${RELEASE_VERSION}/index.html"
+        )
+
+        for key in "${required_keys[@]}"; do
+          if ! aws s3api head-object --bucket "${DOCS_STATIC_BUCKET}" --key "${key}" >/dev/null; then
+            echo "Missing docs release asset: s3://${DOCS_STATIC_BUCKET}/${key}" >&2
+            exit 1
+          fi
+        done

--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -6,16 +6,6 @@ name: Android Release Build
 on:
   workflow_dispatch:
     inputs:
-      # Auto-generated from .version by sync-version-file.yml
-      # VERSION_INPUT_BEGIN
-      version_preview:
-        description: "Version from .version (read-only preview)"
-        required: true
-        type: choice
-        options:
-          - "2.3.0"
-        default: "2.3.0"
-      # VERSION_INPUT_END
       allow_overwrite_release:
         description: "Allow overwrite of existing release APK"
         required: false
@@ -27,7 +17,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: android-release-build-${{ github.run_id }}
+  group: android-release-build-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -40,7 +30,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -49,45 +39,35 @@ jobs:
           distribution: zulu
           cache: gradle
 
-      - name: Validate release input
+      - name: Resolve release version
         id: release
         shell: bash
-        env:
-          RELEASE_VERSION: ${{ inputs.version_preview }}
         run: |
           set -euo pipefail
-          if [[ "${RELEASE_VERSION}" == *"-SNAPSHOT" ]]; then
-            echo "Expected a release version without -SNAPSHOT suffix, got: ${RELEASE_VERSION}" >&2
-            exit 1
-          fi
-          echo "version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+          release_version="$(bash .github/scripts/resolve-release-version.sh)"
+          echo "version=${release_version}" >> "$GITHUB_OUTPUT"
 
-      - name: Decode keystore
-        env:
-          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${ANDROID_RELEASE_KEYSTORE_BASE64:-}" ]]; then
-            echo "Missing required secret: ANDROID_RELEASE_KEYSTORE_BASE64" >&2
-            exit 1
-          fi
-          printenv ANDROID_RELEASE_KEYSTORE_BASE64 | base64 -d > androidApp/release.keystore
+      - name: Prepare Android signing
+        uses: ./.github/actions/prepare-android-signing
+        with:
+          keystore-base64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+          store-password: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          key-alias: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          key-password: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
 
       - name: Assemble androidApp release with release dependencies
         shell: bash
-        env:
-          ORG_GRADLE_PROJECT_ANDROID_RELEASE_STORE_FILE: androidApp/release.keystore
-          ORG_GRADLE_PROJECT_ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
-          ORG_GRADLE_PROJECT_ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
-          ORG_GRADLE_PROJECT_ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
           ./gradlew :androidApp:assembleRelease \
             -PchartsDependencyMode=release \
             -PchartsPublishedVersion=${{ steps.release.outputs.version }} \
             --no-daemon
-          rm -f androidApp/release.keystore
+
+      - name: Remove Android signing keystore
+        if: always()
+        shell: bash
+        run: rm -f androidApp/release.keystore
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/android-snapshot-build.yml
+++ b/.github/workflows/android-snapshot-build.yml
@@ -5,17 +5,6 @@
 name: Android Snapshot Build
 on:
   workflow_dispatch:
-    inputs:
-      # Auto-generated from .version by sync-version-file.yml
-      # VERSION_INPUT_BEGIN
-      version_preview:
-        description: "Version from .version (read-only preview)"
-        required: true
-        type: choice
-        options:
-          - "2.3.0-SNAPSHOT"
-        default: "2.3.0-SNAPSHOT"
-      # VERSION_INPUT_END
 
 permissions:
   contents: read
@@ -47,42 +36,40 @@ jobs:
       - name: Validate snapshot input
         id: snapshot
         shell: bash
-        env:
-          SNAPSHOT_VERSION: ${{ inputs.version_preview }}
         run: |
           set -euo pipefail
+          SNAPSHOT_VERSION="$(awk 'NF {gsub(/\r/, "", $0); print $0; exit}' .version)"
+          if [[ -z "${SNAPSHOT_VERSION:-}" ]]; then
+            echo "Failed to resolve snapshot version from .version." >&2
+            exit 1
+          fi
           if [[ "${SNAPSHOT_VERSION}" != *"-SNAPSHOT" ]]; then
             echo "Expected a -SNAPSHOT version, got: ${SNAPSHOT_VERSION}" >&2
             exit 1
           fi
           echo "version=${SNAPSHOT_VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Decode keystore
-        env:
-          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${ANDROID_RELEASE_KEYSTORE_BASE64:-}" ]]; then
-            echo "Missing required secret: ANDROID_RELEASE_KEYSTORE_BASE64" >&2
-            exit 1
-          fi
-          printenv ANDROID_RELEASE_KEYSTORE_BASE64 | base64 -d > androidApp/release.keystore
+      - name: Prepare Android signing
+        uses: ./.github/actions/prepare-android-signing
+        with:
+          keystore-base64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+          store-password: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          key-alias: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          key-password: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
 
       - name: Assemble androidApp release with snapshot dependencies
         shell: bash
-        env:
-          ORG_GRADLE_PROJECT_ANDROID_RELEASE_STORE_FILE: androidApp/release.keystore
-          ORG_GRADLE_PROJECT_ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
-          ORG_GRADLE_PROJECT_ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
-          ORG_GRADLE_PROJECT_ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
           ./gradlew :androidApp:assembleRelease \
             -PchartsDependencyMode=snapshot \
             -PchartsPublishedVersion=${{ steps.snapshot.outputs.version }} \
             --no-daemon
-          rm -f androidApp/release.keystore
+
+      - name: Remove Android signing keystore
+        if: always()
+        shell: bash
+        run: rm -f androidApp/release.keystore
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/android-snapshot-build.yml
+++ b/.github/workflows/android-snapshot-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -33,14 +33,15 @@ jobs:
           distribution: zulu
           cache: gradle
 
-      - name: Validate snapshot input
+      - name: Resolve snapshot version
         id: snapshot
         shell: bash
         run: |
           set -euo pipefail
-          SNAPSHOT_VERSION="$(awk 'NF {gsub(/\r/, "", $0); print $0; exit}' .version)"
+          SNAPSHOT_VERSION="$(./gradlew -q currentVersion \
+            | awk 'NF {v=$NF} END {gsub(/\r/, "", v); print v}')"
           if [[ -z "${SNAPSHOT_VERSION:-}" ]]; then
-            echo "Failed to resolve snapshot version from .version." >&2
+            echo "Failed to resolve snapshot version." >&2
             exit 1
           fi
           if [[ "${SNAPSHOT_VERSION}" != *"-SNAPSHOT" ]]; then

--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -8,6 +8,11 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
+    inputs:
+      baseline_ref:
+        description: "Optional baseline ref for manual release audits, for example 2.2.0"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -39,11 +44,18 @@ jobs:
         id: compatibility
         continue-on-error: true
         shell: bash
+        env:
+          BASELINE_REF: ${{ github.event.inputs.baseline_ref }}
         run: |
           set +e
           set -o pipefail
 
-          ./gradlew apiCompatibilityCheck --no-daemon 2>&1 | tee api-compatibility.log
+          args=(apiCompatibilityCheck --no-daemon)
+          if [[ -n "${BASELINE_REF:-}" ]]; then
+            args+=("-PapiCompatibilityBaselineRef=${BASELINE_REF}")
+          fi
+
+          ./gradlew "${args[@]}" 2>&1 | tee api-compatibility.log
           exit_code=${PIPESTATUS[0]}
           set -e
           echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/promote-docs.yml
+++ b/.github/workflows/promote-docs.yml
@@ -5,17 +5,6 @@
 name: Promote Docs
 on:
   workflow_dispatch:
-    inputs:
-      # Auto-generated from .version by sync-version-file.yml
-      # VERSION_INPUT_BEGIN
-      version_preview:
-        description: "Version from .version (read-only preview)"
-        required: true
-        type: choice
-        options:
-          - "2.3.0"
-        default: "2.3.0"
-      # VERSION_INPUT_END
 
 permissions:
   contents: read

--- a/.github/workflows/publish-docs-release.yml
+++ b/.github/workflows/publish-docs-release.yml
@@ -6,16 +6,6 @@ name: Publish Docs Release
 on:
   workflow_dispatch:
     inputs:
-      # Auto-generated from .version by sync-version-file.yml
-      # VERSION_INPUT_BEGIN
-      version_preview:
-        description: "Version from .version (read-only preview)"
-        required: true
-        type: choice
-        options:
-          - "2.3.0"
-        default: "2.3.0"
-      # VERSION_INPUT_END
       allow_overwrite_release:
         description: "Allow overwrite of existing release assets"
         required: false
@@ -97,25 +87,10 @@ jobs:
           fetch-depth: 1
           path: charts-docs-repo
 
-      - name: Validate release version exists in charts-docs registry
-        shell: bash
-        env:
-          EXPECTED_VERSION: ${{ steps.version.outputs.charts_version }}
-        run: |
-          set -euo pipefail
-          registry_path="charts-docs-repo/registry/versions.json"
-          if [[ ! -f "${registry_path}" ]]; then
-            echo "Missing charts-docs registry: ${registry_path}" >&2
-            exit 1
-          fi
-
-          if ! jq -e --arg expected "${EXPECTED_VERSION}" \
-            'any((.versions // [])[]?; .id == $expected)' "${registry_path}" >/dev/null; then
-            available_versions="$(jq -r '[(.versions // [])[]? | .id | select(type == "string" and . != "")] | join(", ")' "${registry_path}")"
-            echo "Release version ${EXPECTED_VERSION} is not present in charts-docs registry." >&2
-            echo "Available registry versions: ${available_versions:-"(none)"}" >&2
-            exit 1
-          fi
+      - name: Validate docs release version
+        uses: ./.github/actions/validate-docs-release-version
+        with:
+          release-version: ${{ steps.version.outputs.charts_version }}
 
       - name: Validate docs release link contract
         shell: bash

--- a/.github/workflows/publish-docs-snapshot.yml
+++ b/.github/workflows/publish-docs-snapshot.yml
@@ -5,17 +5,6 @@
 name: Publish Docs Snapshot
 on:
   workflow_dispatch:
-    inputs:
-      # Auto-generated from .version by sync-version-file.yml
-      # VERSION_INPUT_BEGIN
-      version_preview:
-        description: "Version from .version (read-only preview)"
-        required: true
-        type: choice
-        options:
-          - "2.3.0-SNAPSHOT"
-        default: "2.3.0-SNAPSHOT"
-      # VERSION_INPUT_END
   schedule:
     # Daily at 00:00 UTC.
     - cron: "0 0 * * *"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,19 @@
 # Workflow: publish a release build of charts.
-# It creates the git tag and updates charts-docs release assets.
+# It creates the git tag and publishes Maven artifacts.
 #
 # Use this for the final release path, not for snapshot or CI validation.
 name: Release
 on:
   workflow_dispatch:
-    inputs:
-      # Auto-generated from .version by sync-version-file.yml
-      # VERSION_INPUT_BEGIN
-      version_preview:
-        description: "Version from .version (read-only preview)"
-        required: true
-        type: choice
-        options:
-          - "2.3.0"
-        default: "2.3.0"
-      # VERSION_INPUT_END
 
 permissions:
   contents: write
+  id-token: write
   issues: write
   pull-requests: write
 
 concurrency:
-  group: release-${{ github.run_id }}
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -65,7 +55,7 @@ jobs:
           set -euo pipefail
           VERSION="${{ steps.version.outputs.release_version }}"
           if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
-            echo "❌ Tag already exists: ${VERSION}" >&2
+            echo "Release tag already exists: ${VERSION}" >&2
             exit 1
           fi
 
@@ -76,81 +66,52 @@ jobs:
           fetch-depth: 1
           path: charts-docs-repo
 
-      - name: Validate release version exists in charts-docs registry
-        shell: bash
-        env:
-          EXPECTED_VERSION: ${{ steps.version.outputs.release_version }}
-        run: |
-          set -euo pipefail
-          registry_path="charts-docs-repo/registry/versions.json"
-          if [[ ! -f "${registry_path}" ]]; then
-            echo "Missing charts-docs registry: ${registry_path}" >&2
-            exit 1
-          fi
+      - name: Validate docs release version
+        uses: ./.github/actions/validate-docs-release-version
+        with:
+          release-version: ${{ steps.version.outputs.release_version }}
 
-          if ! jq -e --arg expected "${EXPECTED_VERSION}" \
-            'any((.versions // [])[]?; .id == $expected)' "${registry_path}" >/dev/null; then
-            available_versions="$(jq -r '[(.versions // [])[]? | .id | select(type == "string" and . != "")] | join(", ")' "${registry_path}")"
-            echo "Release version ${EXPECTED_VERSION} is not present in charts-docs registry." >&2
-            echo "Available registry versions: ${available_versions:-"(none)"}" >&2
-            exit 1
-          fi
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
-      - name: Check required secrets
-        id: secrets_check
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          SIGNING_IN_MEMORY_KEY: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          missing=0
-          for v in MAVEN_CENTRAL_USERNAME MAVEN_CENTRAL_PASSWORD SIGNING_KEY_ID SIGNING_PASSWORD SIGNING_IN_MEMORY_KEY; do
-            if [ -z "${!v:-}" ]; then
-              echo "Missing secret: $v" >&2
-              missing=1
-            fi
-          done
-          if [ "$missing" -eq 0 ]; then
-            echo "can_publish=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "can_publish=false" >> "$GITHUB_OUTPUT"
-            echo "Release publish cannot proceed because required secrets are missing." >&2
-            exit 1
-          fi
+      - name: Validate docs static release
+        uses: ./.github/actions/validate-docs-static-release
+        with:
+          release-version: ${{ steps.version.outputs.release_version }}
+          source-sha: ${{ github.sha }}
+          docs-static-bucket: ${{ vars.DOCS_STATIC_BUCKET }}
+
+      - name: Prepare Maven publishing
+        uses: ./.github/actions/prepare-maven-publishing
+        with:
+          maven-central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          signing-key-id: ${{ secrets.SIGNING_KEY_ID }}
+          signing-password: ${{ secrets.SIGNING_PASSWORD }}
+          signing-in-memory-key: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
 
       - name: Create release tag locally with Axion
-        if: ${{ steps.secrets_check.outputs.can_publish == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
           ./gradlew createRelease --no-daemon --stacktrace
 
       - name: Publish to Maven Central
-        if: ${{ steps.secrets_check.outputs.can_publish == 'true' }}
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: |
           ./gradlew publishChartsModules \
             -PchartsReleaseVersion="${{ steps.version.outputs.release_version }}" \
             --no-daemon --no-build-cache --stacktrace
 
       - name: Push release tag with Axion
-        if: ${{ steps.secrets_check.outputs.can_publish == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
           ./gradlew pushRelease --no-daemon --stacktrace
 
       - name: Comment on success
-        if: ${{ steps.secrets_check.outputs.can_publish == 'true' }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -5,17 +5,6 @@
 name: Snapshot Release
 on:
   workflow_dispatch:
-    inputs:
-      # Auto-generated from .version by sync-version-file.yml
-      # VERSION_INPUT_BEGIN
-      version_preview:
-        description: "Version from .version (read-only preview)"
-        required: true
-        type: choice
-        options:
-          - "2.3.0-SNAPSHOT"
-        default: "2.3.0-SNAPSHOT"
-      # VERSION_INPUT_END
 
 permissions:
   contents: write
@@ -108,47 +97,24 @@ jobs:
           echo "snapshot_version=${SNAPSHOT_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Config chartsVersion: ${SNAPSHOT_VERSION}"
 
-      - name: Check required secrets
+      - name: Prepare Maven publishing
         if: ${{ steps.version.outputs.is_snapshot == 'true' }}
-        id: secrets_check
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          SIGNING_IN_MEMORY_KEY: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          missing=0
-          for v in MAVEN_CENTRAL_USERNAME MAVEN_CENTRAL_PASSWORD SIGNING_KEY_ID SIGNING_PASSWORD SIGNING_IN_MEMORY_KEY; do
-            if [ -z "${!v:-}" ]; then
-              echo "Missing secret: $v" >&2
-              missing=1
-            fi
-          done
-          if [ "$missing" -eq 0 ]; then
-            echo "can_publish=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "can_publish=false" >> "$GITHUB_OUTPUT"
-            echo "Snapshot publish cannot proceed because required secrets are missing." >&2
-            exit 1
-          fi
+        uses: ./.github/actions/prepare-maven-publishing
+        with:
+          maven-central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          signing-key-id: ${{ secrets.SIGNING_KEY_ID }}
+          signing-password: ${{ secrets.SIGNING_PASSWORD }}
+          signing-in-memory-key: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
 
       - name: Publish snapshot to Maven Central
-        if: ${{ steps.version.outputs.is_snapshot == 'true' && steps.secrets_check.outputs.can_publish == 'true' }}
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+        if: ${{ steps.version.outputs.is_snapshot == 'true' }}
         run: |
           echo "Publishing snapshot version: ${{ steps.version.outputs.snapshot_version }}"
           ./gradlew publishChartsModules --no-daemon --stacktrace
 
       - name: Comment on commit
-        if: ${{ steps.version.outputs.is_snapshot == 'true' && steps.secrets_check.outputs.can_publish == 'true' }}
+        if: ${{ steps.version.outputs.is_snapshot == 'true' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -217,9 +183,6 @@ jobs:
               repo,
               workflow_id: workflowId,
               ref: context.ref,
-              inputs: {
-                version_preview: '${{ needs.snapshot-release.outputs.snapshot_version }}'
-              }
             });
             
             console.log(`Triggered ${workflowId} with version ${{ needs.snapshot-release.outputs.snapshot_version }}`);

--- a/.github/workflows/sync-version-file.yml
+++ b/.github/workflows/sync-version-file.yml
@@ -1,5 +1,4 @@
 # Workflow: keep the checked-in .version file in sync with Axion.
-# It also refreshes workflow version inputs for release and snapshot jobs.
 #
 # This runs on main branch pushes.
 name: Sync Version File
@@ -45,75 +44,7 @@ jobs:
             exit 1
           fi
           printf '%s\n' "${charts_version}" > .version
-          preview_version="$(awk 'NF {gsub(/\r/, "", $0); print $0; exit}' .version)"
-          if [[ -z "${preview_version:-}" ]]; then
-            echo "The .version file is empty." >&2
-            exit 1
-          fi
-          release_preview_version="${preview_version%-SNAPSHOT}"
-          if [[ -z "${release_preview_version:-}" ]]; then
-            echo "Failed to derive release preview version from ${preview_version}." >&2
-            exit 1
-          fi
-
-          workflow_files=(
-            ".github/workflows/publish-docs-release.yml"
-            ".github/workflows/release.yml"
-            ".github/workflows/snapshot-release.yml"
-            ".github/workflows/publish-docs-snapshot.yml"
-            ".github/workflows/promote-docs.yml"
-            ".github/workflows/android-snapshot-build.yml"
-            ".github/workflows/android-release-build.yml"
-          )
-
-          for workflow_file in "${workflow_files[@]}"; do
-            case "${workflow_file}" in
-              ".github/workflows/release.yml"|".github/workflows/publish-docs-release.yml"|".github/workflows/promote-docs.yml"|".github/workflows/android-release-build.yml")
-                workflow_preview_version="${release_preview_version}"
-                ;;
-              *)
-                workflow_preview_version="${preview_version}"
-                ;;
-            esac
-
-            begin_count="$(grep -c "# VERSION_INPUT_BEGIN" "${workflow_file}" || true)"
-            end_count="$(grep -c "# VERSION_INPUT_END" "${workflow_file}" || true)"
-            if [[ "${begin_count}" -ne 1 || "${end_count}" -ne 1 ]]; then
-              echo "Expected exactly one VERSION_INPUT marker pair in ${workflow_file}." >&2
-              exit 1
-            fi
-
-            tmp_file="$(mktemp)"
-            awk -v v="${workflow_preview_version}" '
-              /# VERSION_INPUT_BEGIN/ {
-                print
-                print "      version_preview:"
-                print "        description: \"Version from .version (read-only preview)\""
-                print "        required: true"
-                print "        type: choice"
-                print "        options:"
-                print "          - \"" v "\""
-                print "        default: \"" v "\""
-                skip=1
-                next
-              }
-              /# VERSION_INPUT_END/ {
-                skip=0
-                print
-                next
-              }
-              !skip { print }
-            ' "${workflow_file}" > "${tmp_file}"
-            mv "${tmp_file}" "${workflow_file}"
-          done
-
           echo "charts_version=${charts_version}" >> "$GITHUB_OUTPUT"
-          {
-            echo "sync_paths<<EOF"
-            echo ".version"
-            printf '%s\n' "${workflow_files[@]}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
 
       - name: Publish resolved version in run summary
         shell: bash
@@ -123,23 +54,10 @@ jobs:
           echo "- Version: \`${{ steps.version.outputs.charts_version }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- File: \`.version\`" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Validate workflow update token
-        shell: bash
-        env:
-          CHARTS_WORKFLOW_TOKEN: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${CHARTS_WORKFLOW_TOKEN:-}" ]]; then
-            echo "Missing required secret: CHARTS_WORKFLOW_TOKEN." >&2
-            echo "Syncing workflow files requires a token with workflow write scope." >&2
-            exit 1
-          fi
-
       - name: Create PR when .version changed
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
-          add-paths: ${{ steps.version.outputs.sync_paths }}
+          add-paths: .version
           branch: chore/sync-version-file
           delete-branch: true
           commit-message: "chore: sync .version"

--- a/buildSrc/src/main/kotlin/charts.api-compatibility.gradle.kts
+++ b/buildSrc/src/main/kotlin/charts.api-compatibility.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 }
 
 val apiCompatibilityBaselineJarsDirProperty = "apiCompatibilityBaselineJarsDir"
+val apiCompatibilityBaselineRefProperty = "apiCompatibilityBaselineRef"
 val apiCompatibilityBaselineFilePath = ".github/api-compatibility-baseline.txt"
 val apiCompatibilityDefaultBaselineJarsDir = "api-compatibility/baseline-jars"
 // japicmp --exclude expects wildcard expressions, not regex.
@@ -29,7 +30,13 @@ fun Project.baselineJarsDir(): File =
             .get()
             .asFile
 
-fun Project.resolveBaselineRefFromFile(): String {
+fun Project.resolveBaselineRef(): String {
+    providers
+        .gradleProperty(apiCompatibilityBaselineRefProperty)
+        .orNull
+        ?.takeIf { it.isNotBlank() }
+        ?.let { return it }
+
     val baselineFile = rootProject.file(apiCompatibilityBaselineFilePath)
     if (!baselineFile.isFile) {
         throw GradleException(
@@ -49,6 +56,7 @@ fun Project.resolveBaselineRefFromFile(): String {
 fun Project.execAndGetStdout(
     args: List<String>,
     workingDir: File = rootProject.rootDir,
+    ignoreExitCode: Boolean = false,
 ): String {
     val process =
         ProcessBuilder(args)
@@ -57,7 +65,7 @@ fun Project.execAndGetStdout(
             .start()
     val output = process.inputStream.bufferedReader().readText()
     val exitCode = process.waitFor()
-    if (exitCode != 0) {
+    if (exitCode != 0 && !ignoreExitCode) {
         throw GradleException(
             "Command failed (${args.joinToString(" ")}): ${output.trim()}",
         )
@@ -85,12 +93,20 @@ tasks.register("prepareApiCompatibilityBaselineJars") {
         project.delete(baselineJarsDir)
         baselineJarsDir.mkdirs()
 
-        val baselineRef = project.resolveBaselineRefFromFile()
+        val baselineRef = project.resolveBaselineRef()
         val baselineSha =
             project.execAndGetStdout(
                 listOf("git", "rev-parse", "-q", "--verify", "$baselineRef^{commit}"),
             )
         val baselineWorktreeDir = File(temporaryDir, "baseline-src").absoluteFile
+        project.execAndGetStdout(
+            listOf("git", "worktree", "remove", "--force", baselineWorktreeDir.absolutePath),
+            ignoreExitCode = true,
+        )
+        project.execAndGetStdout(
+            listOf("git", "worktree", "prune"),
+            ignoreExitCode = true,
+        )
         project.delete(baselineWorktreeDir)
         baselineWorktreeDir.parentFile.mkdirs()
 
@@ -198,6 +214,6 @@ val apiCompatibilityTasks =
 tasks.register("apiCompatibilityCheck") {
     group = "verification"
     description =
-        "Checks published JVM artifacts for breaking API changes using baseline ref from .github/api-compatibility-baseline.txt (or -P$apiCompatibilityBaselineJarsDirProperty override)."
+        "Checks published JVM artifacts for breaking API changes using baseline ref from .github/api-compatibility-baseline.txt (or -P$apiCompatibilityBaselineRefProperty / -P$apiCompatibilityBaselineJarsDirProperty override)."
     dependsOn(apiCompatibilityTasks)
 }

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -8,5 +8,6 @@ This directory contains release workflow diagrams split by flow.
 - [Docs Release Publish](./docs-release-publish.md)
 - [Docs Snapshot Publish](./docs-snapshot-publish.md)
 - [Docs Promotion (Cross-Repo)](./docs-promotion.md)
+- [Versioning](./versioning.md)
 - [Release Notes Sync](./release-notes-sync.md)
 - [Release Checklist](./release-checklist.md)

--- a/docs/release/charts-release.md
+++ b/docs/release/charts-release.md
@@ -7,21 +7,31 @@ flowchart TD
   A["workflow_dispatch"] --> B["Checkout + JDK"]
   B --> C["axion: resolve-release-version.sh"]
   C --> E["Gradle (Axion): verifyRelease"]
-  E --> F{"Tag already exists?"}
+  E --> F{"Release tag exists?"}
   F -- Yes --> FX["Fail"]
   F -- No --> G["Checkout charts-docs"]
   G --> H{"Version exists in charts-docs registry?"}
   H -- No --> HX["Fail"]
-  H -- Yes --> I["Check Maven/signing secrets"]
-  I --> J{"Secrets complete?"}
-  J -- No --> JX["Skip publish steps"]
-  J -- Yes --> K["Gradle (Axion): createRelease (local tag)"]
-  K --> L["Gradle (Charts): publishChartsModules (Maven Central)"]
-  L --> M["Gradle (Axion): pushRelease (tag push)"]
-  M --> N["Commit comment (success)"]
+  H -- Yes --> I["AWS OIDC creds"]
+  I --> J{"Docs/static release published for version + commit?"}
+  J -- No --> JX["Fail"]
+  J -- Yes --> K["Check Maven/signing secrets"]
+  K --> L{"Secrets complete?"}
+  L -- No --> LX["Fail"]
+  L -- Yes --> M["Gradle (Axion): createRelease (local tag)"]
+  M --> N["Gradle (Charts): publishChartsModules (Maven Central)"]
+  N --> O["Gradle (Axion): pushRelease (tag push)"]
+  O --> P["Commit comment (success)"]
 ```
 
 Before running this workflow, complete the
 [Release Checklist](./release-checklist.md). In particular, the docs promotion
 pull request must be merged because this workflow requires the release version
 in the charts-docs registry.
+
+The workflow resolves the release version from Axion. If the release tag already
+exists, the workflow fails before publishing.
+
+The workflow also requires `Docs Release Publish` to have published versioned
+docs/static assets for the same release version and charts commit before Maven
+publishing can proceed.

--- a/docs/release/charts-snapshot.md
+++ b/docs/release/charts-snapshot.md
@@ -19,5 +19,5 @@ flowchart TD
   J --> K["Dispatch Android Snapshot Build"]
 ```
 
-The Android snapshot build resolves the snapshot version from `.version` on the
-dispatched ref.
+`Android Snapshot Build` resolves the snapshot version from Axion on the
+selected ref, matching `Snapshot Release`.

--- a/docs/release/charts-snapshot.md
+++ b/docs/release/charts-snapshot.md
@@ -13,7 +13,11 @@ flowchart TD
   F -- No --> FX["Skip snapshot publish"]
   F -- Yes --> G["Check Maven/signing secrets"]
   G --> H{"Secrets complete?"}
-  H -- No --> HX["Skip publish"]
+  H -- No --> HX["Fail"]
   H -- Yes --> I["Gradle (Charts): publishChartsModules"]
   I --> J["Commit comment"]
+  J --> K["Dispatch Android Snapshot Build"]
 ```
+
+The Android snapshot build resolves the snapshot version from `.version` on the
+dispatched ref.

--- a/docs/release/docs-release-publish.md
+++ b/docs/release/docs-release-publish.md
@@ -22,3 +22,9 @@ flowchart TD
 Required release files:
 - `docs/static/api/{release_version}/index.html`
 - `docs/static/demo/{release_version}/index.html`
+
+The release version is resolved from Axion at runtime. The manual run form only
+contains the overwrite control for existing release assets.
+
+Run this workflow before `Release`; the library release checks the S3 metadata
+and required versioned docs objects before publishing Maven artifacts.

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -8,13 +8,26 @@ manually.
 2. Merge the latest automated charts-docs release-note sync pull request.
 3. Run `Promote Docs` from the charts `main` branch.
 4. Review and merge the generated charts-docs promotion pull request.
-5. Run `Release` from the charts `main` branch.
-6. Run `Docs Release Publish` after the charts release succeeds.
+5. Run `Docs Release Publish` from the charts `main` branch.
+6. Run `Release` from the charts `main` branch.
 
 `Promote Docs` resolves the release version automatically, freezes
 `content/snapshot` as `content/<version>`, and registers the version. The charts
 release and docs release-publish workflows intentionally fail when that
 registry entry is missing.
+
+`Release` also checks that versioned docs/static assets were already published
+to S3 for the same release version and charts commit. This prevents publishing
+the library before the matching public docs are available.
+
+Manual release workflows resolve their versions from Axion or `.version`; the
+manual run form no longer carries generated version preview choices.
+See [Versioning](./versioning.md) for the current minor-by-default policy and
+the unresolved patch/hotfix release strategy.
+
+`Release` creates the git tag locally before publishing to Maven Central and
+pushes it after publishing succeeds. If the workflow fails, rerun `Release` from
+GitHub after resolving the failure.
 
 Release-note directories are already versioned and are not moved or reset
 during promotion.

--- a/docs/release/versioning.md
+++ b/docs/release/versioning.md
@@ -1,0 +1,51 @@
+# Versioning
+
+Release versions are resolved by Axion from Git tags.
+
+The root Gradle build currently uses:
+
+```kotlin
+scmVersion {
+    tag {
+        prefix.set("")
+    }
+    versionIncrementer("incrementMinor")
+}
+```
+
+This means the normal development line increments the minor version after a
+release tag.
+
+Example:
+
+1. Before release, `./gradlew -q currentVersion` resolves `2.3.0-SNAPSHOT`.
+2. `Release` publishes and tags `2.3.0`.
+3. After the `2.3.0` tag exists, Axion resolves the next development version as
+   `2.4.0-SNAPSHOT`.
+4. `Sync Version File` opens a PR to update `.version` to that new snapshot
+   version.
+
+The manual release workflows do not accept a version input. They resolve the
+version from Axion at runtime. Workflows that need a checked-in snapshot version,
+such as Android snapshot builds and release-note synchronization, read
+`.version`.
+
+## Patch Releases
+
+Patch releases are not currently selectable from the release workflow.
+
+With `incrementMinor`, a release from `2.3.0-SNAPSHOT` produces `2.3.0`, and the
+next development version becomes `2.4.0-SNAPSHOT`. It does not automatically
+create `2.3.1-SNAPSHOT`.
+
+Before cutting patch or hotfix releases, choose and document the intended
+strategy. Common options are:
+
+- Change the project default to `versionIncrementer("incrementPatch")`.
+- Add an explicit Gradle property override for the incrementer and wire release
+  workflows to pass it.
+- Use a dedicated hotfix branch policy where patch releases are prepared from a
+  release branch with its own versioning rules.
+
+Until one of those strategies is implemented, treat the release workflow as
+minor-line release automation.

--- a/docs/release/versioning.md
+++ b/docs/release/versioning.md
@@ -25,10 +25,9 @@ Example:
 4. `Sync Version File` opens a PR to update `.version` to that new snapshot
    version.
 
-The manual release workflows do not accept a version input. They resolve the
-version from Axion at runtime. Workflows that need a checked-in snapshot version,
-such as Android snapshot builds and release-note synchronization, read
-`.version`.
+Manual release workflows resolve the version from Axion at runtime.
+Release-note synchronization reads `.version` as the checked-in target snapshot
+marker.
 
 ## Patch Releases
 

--- a/docs/workflows/api-compatibility.md
+++ b/docs/workflows/api-compatibility.md
@@ -20,6 +20,26 @@ flowchart TD
 
 If a breaking change is acknowledged and merged, always run the post-merge baseline update flow below.
 
+## Release Audit Flow
+
+For release readiness, compare against the previous published release tag, not
+necessarily the checked-in `.github/api-compatibility-baseline.txt`. The checked-in
+baseline may be advanced after accepted breaking-change PRs merge, so it can be
+newer than the previous release.
+
+Run the manual workflow with `baseline_ref` set to the previous release tag, or
+run Gradle locally with:
+
+```bash
+./gradlew apiCompatibilityCheck --no-daemon --continue -PapiCompatibilityBaselineRef=<previous-release-tag>
+```
+
+Example for a `2.3.0` release whose previous release is `2.2.0`:
+
+```bash
+./gradlew apiCompatibilityCheck --no-daemon --continue -PapiCompatibilityBaselineRef=2.2.0
+```
+
 ## Post-Merge Baseline Update Flow
 
 ```mermaid

--- a/release-notes/2.3.0/changes/363-api-compatibility-checks.md
+++ b/release-notes/2.3.0/changes/363-api-compatibility-checks.md
@@ -1,6 +1,0 @@
-# PR Changeset
-
-- type: `feature`
-- module: `charts-core`
-- pr: `https://github.com/HDCharts/charts/pull/363`
-- release_note: `Added automated API compatibility checks to help prevent accidental breaking changes in future releases.`

--- a/release-notes/2.3.0/changes/413-add-histogram-chart.md
+++ b/release-notes/2.3.0/changes/413-add-histogram-chart.md
@@ -3,4 +3,4 @@
 - type: `feature`
 - module: `charts-histogram`
 - pr: `https://github.com/HDCharts/charts/pull/413`
-- release_note: `Add a new histogram chart with customizable styling, selection, and demos across app, docs, and playground.`
+- release_note: `Adds a new histogram chart with customizable styling, selection, and demos across app, docs, and playground.`

--- a/release-notes/2.3.0/changes/443-release-notes-sync.md
+++ b/release-notes/2.3.0/changes/443-release-notes-sync.md
@@ -1,6 +1,0 @@
-# PR Changeset
-
-- type: `docs`
-- module: `charts`
-- pr: `https://github.com/HDCharts/charts/pull/443`
-- release_note: `Release notes and migration guidance now sync through the new release workflow.`

--- a/release-notes/2.3.0/migrations/394-chart-aspect-ratio-toggle.md
+++ b/release-notes/2.3.0/migrations/394-chart-aspect-ratio-toggle.md
@@ -1,5 +1,9 @@
 ## charts-core
 
+### Reported API symbols
+
+- `io.github.dautovicharis.charts.style.ChartViewDefaults.style(...)`
+
 ### Do I need to update call sites?
 
 - No, if you already call `ChartViewDefaults.style(...)` and keep the default square chart area.
@@ -24,6 +28,10 @@ val chartViewStyle = ChartViewDefaults.style(
 - Recommended: Prefer named arguments when calling style factory functions.
 
 ## charts-pie
+
+### Reported API symbols
+
+- `io.github.dautovicharis.charts.style.PieChartDefaults.style(...)`
 
 ### Do I need to update call sites?
 

--- a/release-notes/2.3.0/migrations/406-bar-chart-per-bar-colors.md
+++ b/release-notes/2.3.0/migrations/406-bar-chart-per-bar-colors.md
@@ -1,5 +1,10 @@
 ## charts-bar
 
+### Reported API symbols
+
+- `io.github.dautovicharis.charts.style.BarChartDefaults.style(...)`
+- `io.github.dautovicharis.charts.internal.BarValidationKt.validateBarData(...)`
+
 ### Do I need to update call sites?
 
 - No, if you call `BarChartDefaults.style(...)` with named arguments only.

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -9,8 +9,11 @@ release-notes/<version>/
 └── migrations/
 ```
 
-- `changes/` contains one short changeset for each user-facing charts pull
-  request.
+- `changes/` contains one short changeset for each public, user-facing charts
+  pull request. Only put text in `release_note` when it belongs in the public
+  "What's New" section. Internal release automation, CI, refactors, and
+  maintenance-only changes should either omit a changeset or keep
+  `release_note` empty.
 - `migrations/` contains one migration fragment for each pull request with
   breaking API changes.
 


### PR DESCRIPTION
Extract common GitHub Actions into reusable composite actions for Android signing, Maven publishing, and docs release validation. 

Remove auto-generated version_preview inputs from workflow_dispatch forms; workflows now resolve versions from Axion or .version at runtime. 

Add docs/static release validation before Maven publishing to ensure public docs are available. Add baseline_ref support to API compatibility checks for release audits. 

Update release documentation, diagrams, and migration guides to reflect the new flow.