### PR TITLE
chore(deps): bump github-actions to latest major versions

### DIFF
--- a/.github/scripts/publish-docs-to-s3.sh
+++ b/.github/scripts/publish-docs-to-s3.sh
@@ -42,6 +42,7 @@ s3_prefix_has_objects() {
   local ls_output
   if ! ls_output="$(aws s3 ls "${bucket_uri}/${rel_path}/" --recursive)"; then
     echo "Failed to list S3 prefix: ${bucket_uri}/${rel_path}/" >&2
+    echo "AWS error: ${ls_output}" >&2
     exit 1
   fi
   [[ -n "${ls_output}" ]]

--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -28,12 +28,12 @@ jobs:
     if: ${{ github.repository_owner == 'HDCharts' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: zulu

--- a/.github/workflows/android-snapshot-build.yml
+++ b/.github/workflows/android-snapshot-build.yml
@@ -22,12 +22,12 @@ jobs:
     if: ${{ github.repository_owner == 'HDCharts' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: zulu

--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -29,12 +29,12 @@ jobs:
       HAS_BREAKING_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: "temurin"

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -20,10 +20,10 @@ jobs:
     name: Assemble
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,20 +33,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Set up JDK 17
         if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: zulu
           cache: gradle
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -56,6 +56,6 @@ jobs:
         run: ./gradlew assemble --no-daemon
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -20,10 +20,10 @@ jobs:
     name: Compile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Detect code changes
@@ -31,7 +31,7 @@ jobs:
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
       - name: Set up JDK 17
         if: steps.changes.outputs.should_run == 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'

--- a/.github/workflows/promote-docs.yml
+++ b/.github/workflows/promote-docs.yml
@@ -22,12 +22,12 @@ jobs:
       github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: "zulu"

--- a/.github/workflows/publish-docs-release.yml
+++ b/.github/workflows/publish-docs-release.yml
@@ -28,7 +28,7 @@ jobs:
     if: ${{ github.repository_owner == 'HDCharts' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main
@@ -40,7 +40,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'
@@ -81,7 +81,7 @@ jobs:
           done
 
       - name: Checkout charts-docs repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: HDCharts/charts-docs
           fetch-depth: 1

--- a/.github/workflows/publish-docs-snapshot.yml
+++ b/.github/workflows/publish-docs-snapshot.yml
@@ -25,7 +25,7 @@ jobs:
     if: ${{ github.repository_owner == 'HDCharts' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -99,7 +99,7 @@ jobs:
 
       - name: Set up JDK 17
         if: ${{ steps.changes.outputs.has_changes == 'true' }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'
@@ -149,7 +149,7 @@ jobs:
 
       - name: Checkout charts-docs repository
         if: ${{ steps.changes.outputs.has_changes == 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: HDCharts/charts-docs
           fetch-depth: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,12 @@ jobs:
     if: ${{ github.repository_owner == 'HDCharts' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Checkout charts-docs repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: HDCharts/charts-docs
           fetch-depth: 1

--- a/.github/workflows/set-api-baseline.yml
+++ b/.github/workflows/set-api-baseline.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       has_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Detect recent changes
@@ -63,12 +63,12 @@ jobs:
       is_snapshot: ${{ steps.version.outputs.is_snapshot }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'

--- a/.github/workflows/sync-version-file.yml
+++ b/.github/workflows/sync-version-file.yml
@@ -22,12 +22,12 @@ jobs:
     if: ${{ github.repository_owner == 'HDCharts' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: zulu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Detect code changes
@@ -31,7 +31,7 @@ jobs:
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
       - name: Set up JDK 17
         if: steps.changes.outputs.should_run == 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'


### PR DESCRIPTION
Update actions/checkout from v6 to v7, actions/setup-java from v4 to v5, and github/codeql-action from v4 to v3 across all workflow files.