### PR TITLE
fix(release): pass release version to verifyRelease task [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ./gradlew verifyRelease --no-daemon --stacktrace
+          ./gradlew verifyRelease \
+            -PchartsReleaseVersion="${{ steps.version.outputs.release_version }}" \
+            --no-daemon --stacktrace
 
       - name: Verify tag does not already exist
         shell: bash


### PR DESCRIPTION
Ensure the chartsReleaseVersion property is passed to the Gradle command so version validation uses the correct release version from the workflow.