### PR TITLE
fix(ci): pass release version to tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ./gradlew createRelease --no-daemon --stacktrace
+          ./gradlew createRelease \
+            -PchartsReleaseVersion="${{ steps.version.outputs.release_version }}" \
+            --no-daemon --stacktrace
 
       - name: Publish to Maven Central
         run: |


### PR DESCRIPTION
## Summary

Pass the resolved release version to Axion tag creation.

## Release/Changeset

- Not required (technical/internal-only)

## Notes/Risk

- None