### PR TITLE
chore: publish playground snapshot assets

### DIFF
--- a/.github/scripts/publish-docs-to-s3.sh
+++ b/.github/scripts/publish-docs-to-s3.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 mode="${1:-}"
 asset="${2:-}"
 if [[ -z "${mode}" || -z "${asset}" ]]; then
-  echo "Usage: $0 <release|snapshot> <api|demo|shared|metadata>" >&2
+  echo "Usage: $0 <release|snapshot> <api|demo|playground|shared|metadata>" >&2
   exit 1
 fi
 
@@ -15,11 +15,11 @@ fi
 
 bucket_uri="s3://${DOCS_STATIC_BUCKET}/static"
 
-sync_subdir() {
-  local rel_path="$1"
-  local cache_control="$2"
-  local include_only_show_errors="${3:-false}"
-  local src="docs/static/${rel_path}"
+sync_source_dir() {
+  local src="$1"
+  local rel_path="$2"
+  local cache_control="$3"
+  local include_only_show_errors="${4:-false}"
   local dst="${bucket_uri}/${rel_path}"
 
   if [[ ! -d "${src}" ]]; then
@@ -37,6 +37,13 @@ sync_subdir() {
   fi
 
   "${args[@]}"
+}
+
+sync_subdir() {
+  local rel_path="$1"
+  local cache_control="$2"
+  local include_only_show_errors="${3:-false}"
+  sync_source_dir "docs/static/${rel_path}" "${rel_path}" "${cache_control}" "${include_only_show_errors}"
 }
 
 s3_prefix_has_objects() {
@@ -95,10 +102,11 @@ claim_release_asset() {
 }
 
 validate_asset() {
-  case "${asset}" in
-    api|demo|shared|metadata) ;;
+  case "${mode}:${asset}" in
+    release:api|release:demo|release:shared|release:metadata|\
+    snapshot:api|snapshot:demo|snapshot:playground|snapshot:shared|snapshot:metadata) ;;
     *)
-      echo "Unsupported static asset: ${asset}" >&2
+      echo "Unsupported mode/asset combination: ${mode} ${asset}" >&2
       exit 1
       ;;
   esac
@@ -147,6 +155,13 @@ case "${mode}" in
     case "${asset}" in
       api|demo)
         sync_subdir "${asset}/snapshot" "${cache_control_snapshot}" "true"
+        ;;
+      playground)
+        sync_source_dir \
+          "${PLAYGROUND_DIST_DIR:-playground/build/dist/js/developmentExecutable}" \
+          "playground/snapshot" \
+          "${cache_control_snapshot}" \
+          "true"
         ;;
       shared)
         if [[ -d docs/static ]]; then

--- a/.github/workflows/publish-static-assets.yml
+++ b/.github/workflows/publish-static-assets.yml
@@ -1,4 +1,5 @@
-# Reusable publication of the static API reference and demo.  Releases and
+# Reusable publication of the static API reference, demo, and snapshot
+# playground. Releases and
 # snapshots share the mechanics but retain separate callers and policies.
 name: Publish Static Assets
 
@@ -133,10 +134,78 @@ jobs:
         shell: bash
         run: bash .github/scripts/publish-docs-to-s3.sh "${{ inputs.mode }}" demo
 
+  publish-playground:
+    name: Publish playground
+    if: ${{ inputs.mode == 'snapshot' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: Snapshot
+    steps:
+      - name: Checkout charts source
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.source-ref }}
+      - name: Checkout charts-playground
+        uses: actions/checkout@v7
+        with:
+          repository: HDCharts/charts-playground
+          ref: main
+          path: playground-repo
+          fetch-depth: 1
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: zulu
+          cache: gradle
+      - name: Build playground static assets
+        working-directory: playground-repo
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./gradlew -DchartsLocalPath=.. :playground:jsBrowserDevelopmentExecutableDistribution \
+            --no-daemon --stacktrace --build-cache
+      - name: Validate playground static assets
+        working-directory: playground-repo
+        shell: bash
+        run: |
+          set -euo pipefail
+          required_files=(
+            playground/build/dist/js/developmentExecutable/index.html
+            playground/build/dist/js/developmentExecutable/Playground.js
+          )
+          for file in "${required_files[@]}"; do
+            if [[ ! -f "${file}" ]]; then
+              echo "Missing required playground file: ${file}" >&2
+              exit 1
+            fi
+          done
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Publish playground snapshot
+        working-directory: playground-repo
+        env:
+          CHARTS_VERSION: ${{ inputs.charts-version }}
+          SOURCE_SHA: ${{ inputs.source-sha }}
+          DOCS_STATIC_BUCKET: ${{ vars.DOCS_STATIC_BUCKET }}
+          PLAYGROUND_DIST_DIR: playground/build/dist/js/developmentExecutable
+        shell: bash
+        run: bash ../.github/scripts/publish-docs-to-s3.sh snapshot playground
+
   publish-shared-static-assets:
     name: Publish shared static assets
     runs-on: ubuntu-latest
-    needs: [publish-api-reference, publish-demo]
+    needs: [publish-api-reference, publish-demo, publish-playground]
+    if: >-
+      ${{
+        always() &&
+        needs.publish-api-reference.result == 'success' &&
+        needs.publish-demo.result == 'success' &&
+        (needs.publish-playground.result == 'success' || needs.publish-playground.result == 'skipped')
+      }}
     environment: ${{ inputs.mode == 'release' && 'Production' || 'Snapshot' }}
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Why

The static asset workflow did not publish playground snapshot assets.

## Summary

Adds playground snapshot publishing to the charts static asset workflow and teaches the upload script how to handle the playground asset path.

## Changes

- Adds a playground snapshot publish job to the reusable static asset workflow.
- Extends the S3 publish script to accept `playground` for snapshot runs.
- Updates usage and validation so the new asset path is accepted.

## Release/Changeset

- Not required (technical/internal-only)

## Notes/Risk

- The new job only runs for snapshot publishes.
