### PR TITLE
fix(ci): finalize release publication metadata

### DIFF
--- a/.github/workflows/publish-static-assets.yml
+++ b/.github/workflows/publish-static-assets.yml
@@ -227,6 +227,11 @@ jobs:
     name: Finalize static publication
     runs-on: ubuntu-latest
     needs: publish-shared-static-assets
+    if: >-
+      ${{
+        always() &&
+        needs.publish-shared-static-assets.result == 'success'
+      }}
     environment: ${{ inputs.mode == 'release' && 'Production' || 'Snapshot' }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/publish-static-assets.yml
+++ b/.github/workflows/publish-static-assets.yml
@@ -229,7 +229,7 @@ jobs:
     needs: publish-shared-static-assets
     if: >-
       ${{
-        always() &&
+        !cancelled() &&
         needs.publish-shared-static-assets.result == 'success'
       }}
     environment: ${{ inputs.mode == 'release' && 'Production' || 'Snapshot' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,9 +299,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v9
+        env:
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.release_version }}
+          SOURCE_SHA: ${{ needs.prepare-release.outputs.source_sha }}
         with:
           script: |
-            const version = '${{ needs.prepare-release.outputs.release_version }}';
+            const version = process.env.RELEASE_VERSION;
+            const sourceSha = process.env.SOURCE_SHA;
             const message = [
               '🎉 **Release Published Successfully!**',
               '',
@@ -338,9 +342,20 @@ jobs:
               `📚 [Documentation](https://charts.harisdautovic.com/)`,
               `📦 [Maven Central](https://central.sonatype.com/artifact/io.github.dautovicharis/charts/${version})`,
             ].join('\n');
+            const release = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: version,
+              target_commitish: sourceSha,
+              name: `Charts ${version}`,
+              body: message,
+              generate_release_notes: true,
+              draft: false,
+              prerelease: false,
+            });
             await github.rest.repos.createCommitComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
-              body: message,
+              body: `${message}\n\n🔗 [GitHub Release](${release.data.html_url})`,
             });


### PR DESCRIPTION
## Why

The release workflow skipped final publication metadata when the release-only playground job was skipped, causing the Maven validation to reject stale metadata.

## Summary

Ensure final static publication runs after shared assets succeed, including release runs where the playground job is intentionally skipped. This allows release metadata to be refreshed for the current commit.

## Changes

- Add an explicit status check to the final publication job.

## Release/Changeset

- Not required (technical/internal-only)

## Notes/Risk

- None