### PR TITLE
fix(ci): run Axion release from tracking branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,15 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.prepare-release.outputs.source_sha }}
+      - name: Prepare tracking branch for Axion
+        env:
+          SOURCE_SHA: ${{ needs.prepare-release.outputs.source_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --no-tags
+          git switch --create release-source "${SOURCE_SHA}"
+          git branch --set-upstream-to=origin/main release-source
       - uses: actions/setup-java@v5
         with:
           java-version: 17


### PR DESCRIPTION
## Why

The release job checks out the immutable source SHA, leaving the runner in detached HEAD. Axion requires the current branch to track a remote branch, so the release stopped before Maven publishing.

## Summary

Prepare a temporary local tracking branch at the immutable release source before running Axion release tasks. This keeps the release commit fixed while allowing Axion validation and tag publication to proceed.

## Changes

- Fetch `origin/main` in the Maven release job.
- Create `release-source` at the prepared source SHA.
- Configure `release-source` to track `origin/main`.

## Release/Changeset

- Not required (technical/internal-only)

## Notes/Risk

- No library or public behavior changes.
- The release still uses the immutable `source_sha` captured during preparation.