### PR TITLE
docs: sync README version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
   <a href="https://central.sonatype.com/repository/maven-snapshots/io/github/dautovicharis/charts/maven-metadata.xml">
     <img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fgithub%2Fdautovicharis%2Fcharts%2Fmaven-metadata.xml&label=Snapshots&color=4285F4" />
   </a>
-  <img src="https://img.shields.io/badge/Jetpack_Compose-1.10.3-4285F4?logo=jetpackcompose" />
-  <img src="https://img.shields.io/badge/Kotlin-2.3.10-0095D5?logo=kotlin" />
-  <img src="https://img.shields.io/badge/AGP-9.0.1-2E7D32?logo=android" />
+  <img src="https://img.shields.io/badge/Jetpack_Compose-1.11.4-4285F4?logo=jetpackcompose" />
+  <img src="https://img.shields.io/badge/Kotlin-2.4.10-0095D5?logo=kotlin" />
+  <img src="https://img.shields.io/badge/AGP-9.3.1-2E7D32?logo=android" />
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Why

Sync the README badges with the versions currently pinned in Gradle.

## Summary

Updated the public README badges so the documented Jetpack Compose, Kotlin Multiplatform, and AGP versions match the repo configuration.

## Changes

- Updated the README badges for Jetpack Compose, Kotlin, and AGP.

## Release/Changeset

- Pending

## Notes/Risk

- None