### PR TITLE
fix(ci): restore version sync PR token

### DIFF
--- a/.github/workflows/sync-version-file.yml
+++ b/.github/workflows/sync-version-file.yml
@@ -53,9 +53,24 @@ jobs:
           echo "- Version: \`${{ steps.version.outputs.charts_version }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- File: \`.version\`" >> "$GITHUB_STEP_SUMMARY"
 
+      # A dedicated bot token is required because this repository disables
+      # pull-request creation by the default GitHub Actions token.
+      - name: Validate pull request token
+        shell: bash
+        env:
+          CHARTS_WORKFLOW_TOKEN: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CHARTS_WORKFLOW_TOKEN:-}" ]]; then
+            echo "Missing required secret: CHARTS_WORKFLOW_TOKEN." >&2
+            echo "It must be a bot token that can create pull requests in this repository." >&2
+            exit 1
+          fi
+
       - name: Create PR when .version changed
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
           add-paths: .version
           branch: chore/sync-version-file
           delete-branch: true


### PR DESCRIPTION
## Why

The version-sync workflow can push its update branch but cannot create the pull request when it uses the default GitHub Actions token.

## Summary

The workflow now uses the existing release-bot credential to create the version-sync pull request and fails clearly if that credential is unavailable. This restores the automated `.version` update after a release without changing library behavior.

## Changes

- Validate `CHARTS_WORKFLOW_TOKEN` before the PR step.
- Pass that token to the pull-request action.

## Release/Changeset

- Not required (technical/internal-only)

## Notes/Risk

- The configured bot token must retain permission to create pull requests in this repository.