### PR TITLE
chore: remove deprecated KMP and Compose test APIs

### DIFF
--- a/charts-bar/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/BarChartDenseDataTest.kt
+++ b/charts-bar/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/BarChartDenseDataTest.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.BarChart
 import io.github.dautovicharis.charts.internal.TestTags
 import io.github.dautovicharis.charts.model.ChartDataSet

--- a/charts-bar/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/BarChartEdgeInteractionTest.kt
+++ b/charts-bar/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/BarChartEdgeInteractionTest.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.BarChart
 import io.github.dautovicharis.charts.internal.TestTags
 import io.github.dautovicharis.charts.model.ChartDataSet

--- a/charts-bar/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/BarChartTest.kt
+++ b/charts-bar/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/BarChartTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.BarChart
 import io.github.dautovicharis.charts.internal.TestTags
 import io.github.dautovicharis.charts.internal.ValidationErrors.MIN_REQUIRED_BAR

--- a/charts-histogram/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/HistogramChartTest.kt
+++ b/charts-histogram/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/HistogramChartTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.HistogramChart
 import io.github.dautovicharis.charts.internal.TestTags
 import io.github.dautovicharis.charts.internal.ValidationErrors.RULE_COLORS_SIZE_MISMATCH

--- a/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/LineChartDenseDataTest.kt
+++ b/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/LineChartDenseDataTest.kt
@@ -11,8 +11,8 @@ import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.LineChart
 import io.github.dautovicharis.charts.internal.TestTags
 import io.github.dautovicharis.charts.model.ChartDataSet

--- a/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/LineChartTest.kt
+++ b/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/LineChartTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.LineChart
 import io.github.dautovicharis.charts.LineChartRenderMode
 import io.github.dautovicharis.charts.internal.TestTags

--- a/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/MultiLineChartTest.kt
+++ b/charts-line/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/MultiLineChartTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.LineChart
 import io.github.dautovicharis.charts.LineChartRenderMode
 import io.github.dautovicharis.charts.internal.TestTags

--- a/charts-pie/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/PieChartTest.kt
+++ b/charts-pie/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/PieChartTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.IntSize
 import io.github.dautovicharis.charts.PIE_SELECTION_AUTO_DESELECT_TIMEOUT_MS
 import io.github.dautovicharis.charts.PieChart

--- a/charts-radar/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/RadarChartTest.kt
+++ b/charts-radar/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/RadarChartTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.RadarChart
 import io.github.dautovicharis.charts.internal.TestTags
 import io.github.dautovicharis.charts.internal.ValidationErrors.MIN_REQUIRED_RADAR

--- a/charts-stacked-area/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/StackedAreaChartDenseDataTest.kt
+++ b/charts-stacked-area/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/StackedAreaChartDenseDataTest.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.StackedAreaChart
 import io.github.dautovicharis.charts.internal.TestTags
 import io.github.dautovicharis.charts.model.MultiChartDataSet

--- a/charts-stacked-area/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/StackedAreaChartTest.kt
+++ b/charts-stacked-area/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/StackedAreaChartTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.StackedAreaChart
 import io.github.dautovicharis.charts.internal.TestTags
 import io.github.dautovicharis.charts.internal.ValidationErrors.MIN_REQUIRED_STACKED_AREA

--- a/charts-stacked-bar/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/StackedBarChartDenseDataTest.kt
+++ b/charts-stacked-bar/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/StackedBarChartDenseDataTest.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.StackedBarChart
 import io.github.dautovicharis.charts.internal.TestTags
 import io.github.dautovicharis.charts.model.MultiChartDataSet

--- a/charts-stacked-bar/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/StackedBarChartTest.kt
+++ b/charts-stacked-bar/src/commonTest/kotlin/io/github/dautovicharis/charts/ui/StackedBarChartTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.StackedBarChart
 import io.github.dautovicharis.charts.internal.TestTags
 import io.github.dautovicharis.charts.internal.ValidationErrors.RULE_COLORS_SIZE_MISMATCH

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/common/StateTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/common/StateTest.kt
@@ -1,7 +1,7 @@
 package io.github.dautovicharis.charts.unit.common
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import io.github.dautovicharis.charts.internal.common.composable.rememberAnimationState
 import io.github.dautovicharis.charts.internal.common.composable.rememberShowState
 import kotlin.test.Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,6 @@ android.useAndroidX=true
 android.experimental.enableScreenshotTest=true
 
 #MPP
-kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.mpp.enableCInteropCommonization=true
 
 #Development


### PR DESCRIPTION
## Why

The charts build emitted deprecation warnings for the Android source-set layout property and the legacy Compose UI test runner.

## Summary

This PR removes the obsolete KMP layout override and migrates chart tests to the Compose UI test v2 API. It is an internal build/test maintenance change with no production API or behavior changes intended.

## Changes

- Remove `kotlin.mpp.androidSourceSetLayoutVersion=2`.
- Migrate all 14 `runComposeUiTest` usages to `androidx.compose.ui.test.v2.runComposeUiTest`.

## Release/Changeset

- Not required (technical/internal-only)

## Notes/Risk

- Ktlint passed.
- Clean `:charts-demo-shared:compileKotlinIosArm64` passed.
- The full modular test run should be rerun in CI; a local run stalled during Kotlin test compilation.