### PR TITLE
ci: centralize playground snapshot publication

### DIFF
--- a/.github/scripts/invalidate-docs-cloudfront.sh
+++ b/.github/scripts/invalidate-docs-cloudfront.sh
@@ -32,7 +32,8 @@ case "${mode}" in
       --paths \
         "/static/_meta/charts-snapshot-publish.json" \
         "/static/api/snapshot/*" \
-        "/static/demo/snapshot/*"
+        "/static/demo/snapshot/*" \
+        "/static/playground/snapshot/*"
     ;;
   *)
     echo "Unsupported mode: ${mode}" >&2

--- a/.github/scripts/promote-release-docs.sh
+++ b/.github/scripts/promote-release-docs.sh
@@ -19,12 +19,10 @@ fi
 if jq -e --arg version "${release_version}" \
   'any(.versions[]?; .id == $version)' "${docs_dir}/registry/versions.json" >/dev/null; then
   manifest_path="${docs_dir}/docs-app/public/release-manifest.json"
-  if [[ ! -f "${manifest_path}" && "${release_version}" == "2.3.0" ]]; then
-    echo "Bootstrapping provenance for the legacy pre-promoted docs release ${release_version}."
-  elif [[ ! -f "${manifest_path}" ]] || ! jq -e \
+  if [[ ! -f "${manifest_path}" ]] || ! jq -e \
       --arg version "${release_version}" \
       --arg sha "${charts_sha}" \
-      '.releaseVersion == $version and .chartsCommit == $sha' \
+      '.charts_version == $version and .source_sha == $sha' \
       "${manifest_path}" >/dev/null; then
     echo "Existing docs release ${release_version} has no matching charts provenance marker." >&2
     echo "Refusing to reuse immutable release content for charts SHA ${charts_sha}." >&2
@@ -38,6 +36,6 @@ bash .github/scripts/sync-release-notes.sh "${docs_dir}" "${release_version}"
 
 mkdir -p "${docs_dir}/docs-app/public"
 published_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-printf '{"releaseVersion":"%s","chartsCommit":"%s","deployedAt":"%s"}\n' \
-  "${release_version}" "${charts_sha}" "${published_at}" \
+printf '{"source_sha":"%s","charts_version":"%s","published_at":"%s"}\n' \
+  "${charts_sha}" "${release_version}" "${published_at}" \
   > "${docs_dir}/docs-app/public/release-manifest.json"

--- a/.github/workflows/publish-static-assets.yml
+++ b/.github/workflows/publish-static-assets.yml
@@ -161,9 +161,18 @@ jobs:
       - name: Build playground static assets
         working-directory: playground-repo
         shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source-sha }}
+          CHARTS_VERSION: ${{ inputs.charts-version }}
         run: |
           set -euo pipefail
+          PUBLISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          PLAYGROUND_SHA="$(git rev-parse HEAD)"
           ./gradlew -DchartsLocalPath=.. :playground:jsBrowserDevelopmentExecutableDistribution \
+            -PsnapshotMetadataChartsSha="${SOURCE_SHA}" \
+            -PsnapshotMetadataPlaygroundSha="${PLAYGROUND_SHA}" \
+            -PsnapshotMetadataChartsVersion="${CHARTS_VERSION}" \
+            -PsnapshotMetadataPublishedAt="${PUBLISHED_AT}" \
             --no-daemon --stacktrace --build-cache
       - name: Validate playground static assets
         working-directory: playground-repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,10 +116,9 @@ jobs:
           if jq -e --arg version "$RELEASE_VERSION" \
             'any(.versions[]?; .id == $version)' charts-docs-repo/registry/versions.json >/dev/null; then
             manifest="charts-docs-repo/docs-app/public/release-manifest.json"
-            if [[ ! -f "$manifest" && "$RELEASE_VERSION" == "2.3.0" ]]; then
-              echo "::warning::The legacy pre-promoted 2.3.0 docs release will receive its provenance manifest during promotion."
-            elif ! jq -e --arg version "$RELEASE_VERSION" --arg sha "$SOURCE_SHA" \
-              '.releaseVersion == $version and .chartsCommit == $sha' "$manifest" >/dev/null; then
+            if [[ ! -f "$manifest" ]] || ! jq -e \
+              --arg version "$RELEASE_VERSION" --arg sha "$SOURCE_SHA" \
+              '.charts_version == $version and .source_sha == $sha' "$manifest" >/dev/null; then
               echo "Existing docs release ${RELEASE_VERSION} has no matching charts provenance marker." >&2
               exit 1
             fi
@@ -280,8 +279,9 @@ jobs:
           deadline=$((SECONDS + 1200))
           while (( SECONDS < deadline )); do
             manifest="$(curl --fail --silent --show-error --max-time 20 "${base_url}/release-manifest.json?release=${RELEASE_VERSION}&attempt=${SECONDS}" || true)"
-            if jq -e --arg version "$RELEASE_VERSION" --arg sha "$CHARTS_SHA" \
-              '.releaseVersion == $version and .chartsCommit == $sha' <<<"${manifest}" >/dev/null 2>&1 \
+            if jq -e \
+              --arg version "$RELEASE_VERSION" --arg sha "$CHARTS_SHA" \
+              '.charts_version == $version and .source_sha == $sha' <<<"${manifest}" >/dev/null 2>&1 \
               && curl --fail --silent --show-error --max-time 20 "${base_url}/${RELEASE_VERSION}/wiki" >/dev/null \
               && curl --fail --silent --show-error --max-time 20 "${base_url}/${RELEASE_VERSION}/api" >/dev/null \
               && curl --fail --silent --show-error --max-time 20 "${base_url}/demo/${RELEASE_VERSION}/" >/dev/null; then

--- a/docs/release/charts-release.md
+++ b/docs/release/charts-release.md
@@ -27,7 +27,3 @@ exists, the workflow fails before publishing.
 resolved version; leave it disabled for normal releases. The workflow must pass
 the protected `Release Approval` environment before any production publication
 begins.
-
-The already-promoted `2.3.0` docs release predates deployment manifests. Its
-first coordinated release run bootstraps the manifest from the pinned charts
-source SHA. This one-time compatibility path does not apply to later versions.


### PR DESCRIPTION
## Why

Coordinate playground snapshot publication with the immutable charts snapshot source.

## Summary

The reusable static-assets workflow now builds the playground with charts and playground provenance metadata and invalidates the playground snapshot path alongside the other snapshot assets.

## Changes

- Embed charts and playground provenance inputs in the centralized playground build.
- Update release manifest field validation to the current provenance schema.
- Include playground assets in snapshot CloudFront invalidation.

## Release/Changeset

- Not required (technical/internal-only)

## Related PRs

- `charts-playground`: https://github.com/HDCharts/charts-playground/pull/22
- `charts-docs`: https://github.com/HDCharts/charts-docs/pull/63

## Notes/Risk

- Merge the companion playground and docs PRs with this charts PR.