### PR TITLE
chore(ci): orchestrate pull request checks from single workflow

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -1,37 +1,39 @@
-# Workflow: check the public API against the current release baseline.
-# Pull requests can be marked breaking-change to allow intentional incompatibilities.
-#
-# This is the API compatibility gate for release safety.
+# Reusable public API compatibility check for pull request orchestration.
 name: API Compatibility
+
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_call:
+    inputs:
+      has-breaking-label:
+        description: Whether the pull request has the breaking-change label.
+        required: true
+        type: boolean
+      source-sha:
+        description: Immutable merge revision being checked.
+        required: true
+        type: string
 
 permissions:
   contents: read
-
-concurrency:
-  group: api-compatibility-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   api-compatibility:
     name: Compare Public API Against Release
     runs-on: ubuntu-latest
     env:
-      HAS_BREAKING_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
+      HAS_BREAKING_LABEL: ${{ inputs.has-breaking-label }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ inputs.source-sha }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
           java-version: 17
-          distribution: "temurin"
+          distribution: 'zulu'
           cache: gradle
 
       - name: Run API compatibility check
@@ -48,11 +50,9 @@ jobs:
           echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
 
       - name: API compatibility summary
-        id: summary
         if: always()
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
           EXIT_CODE: ${{ steps.compatibility.outputs.exit_code }}
         run: |
           set -euo pipefail
@@ -84,13 +84,6 @@ jobs:
             else
               result="incompatible (breaking-change label missing)"
             fi
-          fi
-
-          if [[ "${EVENT_NAME}" != "pull_request" ]]; then
-            {
-              echo "## API Compatibility"
-              echo "- Result: ${result}"
-            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
           echo "result=${result}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -1,18 +1,16 @@
-# Workflow: build the main charts project for pull requests.
-# Use this when you want a fast Gradle assemble check without running the full test suite.
-#
-# This is a lightweight CI gate for build validation.
+# Reusable assemble check for pull request orchestration.
 name: Assemble
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_call:
+    inputs:
+      source-sha:
+        description: Immutable merge revision being checked.
+        required: true
+        type: string
 
 permissions:
   contents: read
-
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   assemble:
@@ -22,6 +20,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          ref: ${{ inputs.source-sha }}
       - uses: actions/setup-java@v5
         with:
           java-version: 17

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,18 +1,16 @@
-# Workflow: compile the charts project for pull requests.
-# Use this as a lighter check than test to catch build errors early.
-#
-# This is a fast validation step, not the full test suite.
+# Reusable compile check for pull request orchestration.
 name: Compile
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_call:
+    inputs:
+      source-sha:
+        description: Immutable merge revision being checked.
+        required: true
+        type: string
 
 permissions:
   contents: read
-
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   compile:
@@ -22,6 +20,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          ref: ${{ inputs.source-sha }}
       - uses: actions/setup-java@v5
         with:
           java-version: 17

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,18 +1,20 @@
-# Workflow: run Kotlin lint checks on pull requests.
-# It skips when only docs or build-irrelevant files changed.
-#
-# This keeps linting focused on code changes that can affect the build.
+# Reusable Kotlin lint check for pull request orchestration.
 name: Lint
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_call:
+    inputs:
+      should-run:
+        description: Whether the pull request contains code or build changes.
+        required: true
+        type: boolean
+      source-sha:
+        description: Immutable merge revision being checked.
+        required: true
+        type: string
 
 permissions:
   contents: read
-
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   lint:
@@ -22,23 +24,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Detect code changes
-        id: changes
-        run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          SHOULD_RUN="$(bash scripts/ci-has-code-changes.sh "$BASE_SHA" "$HEAD_SHA")"
-          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+          ref: ${{ inputs.source-sha }}
       - name: Set up JDK 17
-        if: steps.changes.outputs.should_run == 'true'
+        if: ${{ inputs.should-run }}
         uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'
           cache: gradle
       - name: Lint
-        if: steps.changes.outputs.should_run == 'true'
+        if: ${{ inputs.should-run }}
         run: ./gradlew ktlintCheck buildSrcKtlintCheck
       - name: Skip lint for docs-only changes
-        if: steps.changes.outputs.should_run != 'true'
+        if: ${{ !inputs.should-run }}
         run: echo "No code/build changes detected. Skipping lint."

--- a/.github/workflows/pr-test-summary-comment.yml
+++ b/.github/workflows/pr-test-summary-comment.yml
@@ -27,7 +27,7 @@ jobs:
         id: pull_request
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const run = context.payload.workflow_run;
@@ -102,7 +102,7 @@ jobs:
           SUMMARY_PATH: ${{ runner.temp }}/ci-summary/ci-test-summary.md
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
           script: |
             const fs = require('fs');
             const { owner, repo } = context.repo;
@@ -149,7 +149,7 @@ jobs:
           PR_HEAD_SHA: ${{ steps.pull_request.outputs.head_sha }}
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const pullRequestNumber = Number(process.env.PR_NUMBER);

--- a/.github/workflows/pr-test-summary-comment.yml
+++ b/.github/workflows/pr-test-summary-comment.yml
@@ -1,18 +1,22 @@
-# Post the latest charts test summary on its pull request.
+# Post the latest charts test summary on the pull request.
+# This workflow is intentionally triggered by workflow_run so fork PRs get a
+# base-repository token without executing pull-request code with write access.
 name: PR Test Summary Comment
+
 on:
   workflow_run:
-    workflows: ["Test"]
+    workflows: ["Pull Request"]
     types: [completed]
 
 permissions:
   actions: read
+  checks: write
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 concurrency:
   group: pr-test-summary-${{ github.event.workflow_run.head_sha }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   comment:
@@ -23,6 +27,7 @@ jobs:
         id: pull_request
         uses: actions/github-script@v9
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const run = context.payload.workflow_run;
@@ -65,43 +70,44 @@ jobs:
               repo,
               pull_number: pullRequestNumber,
             });
-            if (pullRequest.data.head.sha !== run.head_sha) {
-              core.info(
-                `Skipping stale test run ${run.id}: PR #${pullRequestNumber} is now at ${pullRequest.data.head.sha}.`,
-              );
+
+            if (
+              pullRequest.data.state !== 'open' ||
+              pullRequest.data.head.sha !== run.head_sha
+            ) {
+              core.info('PR changed while resolving; skipping comment.');
               core.setOutput('current', 'false');
               return;
             }
 
-            core.setOutput('current', 'true');
             core.setOutput('number', String(pullRequestNumber));
+            core.setOutput('current', 'true');
+            core.setOutput('state', String(pullRequest.data.state));
+            core.setOutput('head_sha', String(pullRequest.data.head.sha));
+            core.setOutput('merge_commit_sha', String(pullRequest.data.merge_commit_sha));
 
       - name: Download test summary
         if: ${{ steps.pull_request.outputs.current == 'true' }}
         uses: actions/download-artifact@v8
         with:
           name: ci-test-summary
-          path: ci-summary
+          path: ${{ runner.temp }}/ci-summary
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create or update PR comment
+        id: publish_comment
         if: ${{ steps.pull_request.outputs.current == 'true' }}
         env:
           PR_NUMBER: ${{ steps.pull_request.outputs.number }}
-          SUMMARY_PATH: ci-summary/ci-test-summary.md
+          SUMMARY_PATH: ${{ runner.temp }}/ci-summary/ci-test-summary.md
         uses: actions/github-script@v9
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const { owner, repo } = context.repo;
             const pullRequestNumber = Number(process.env.PR_NUMBER);
             const marker = '<!-- ci-test-summary -->';
-
-            if (!fs.existsSync(process.env.SUMMARY_PATH)) {
-              throw new Error(`Summary artifact file not found at ${process.env.SUMMARY_PATH}.`);
-            }
-
             const summary = fs.readFileSync(process.env.SUMMARY_PATH, 'utf8').trim();
             const body = `${marker}\n${summary}`;
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -130,5 +136,70 @@ jobs:
                 repo,
                 issue_number: pullRequestNumber,
                 body,
+              });
+            }
+
+      - name: Publish PR summary check
+        if: ${{ always() && steps.pull_request.outputs.current == 'true' }}
+        env:
+          COMMENT_OUTCOME: ${{ steps.publish_comment.outcome }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
+          PR_STATE: ${{ steps.pull_request.outputs.state }}
+          PR_HEAD_SHA: ${{ steps.pull_request.outputs.head_sha }}
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pullRequestNumber = Number(process.env.PR_NUMBER);
+            const checkName = 'PR summary report';
+            const run = context.payload.workflow_run;
+
+            if (
+              process.env.PR_STATE !== 'open' ||
+              process.env.PR_HEAD_SHA !== run.head_sha
+            ) {
+              core.info('PR changed while publishing the summary; skipping stale check.');
+              return;
+            }
+
+            const commentPublished = process.env.COMMENT_OUTCOME === 'success';
+            const parentPassed = process.env.RUN_CONCLUSION === 'success';
+            const passed = commentPublished && parentPassed;
+            const output = {
+              title: 'PR summary report',
+              summary: 'The complete PR summary report was published as a comment.',
+            };
+            const checkRun = {
+              name: checkName,
+              head_sha: run.head_sha,
+              status: 'completed',
+              conclusion: passed ? 'success' : 'failure',
+              output,
+            };
+            const existingChecks = await github.paginate(github.rest.checks.listForRef, {
+              owner,
+              repo,
+              ref: checkRun.head_sha,
+              check_name: checkName,
+              per_page: 100,
+            });
+            const existing = existingChecks.find(
+              (check) => check.app?.slug === 'github-actions',
+            );
+
+            if (existing) {
+              await github.rest.checks.update({
+                owner,
+                repo,
+                check_run_id: existing.id,
+                ...checkRun,
+              });
+            } else {
+              await github.rest.checks.create({
+                owner,
+                repo,
+                ...checkRun,
               });
             }

--- a/.github/workflows/pr-test-summary-comment.yml
+++ b/.github/workflows/pr-test-summary-comment.yml
@@ -27,7 +27,7 @@ jobs:
         id: pull_request
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const run = context.payload.workflow_run;
@@ -102,7 +102,7 @@ jobs:
           SUMMARY_PATH: ${{ runner.temp }}/ci-summary/ci-test-summary.md
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const { owner, repo } = context.repo;
@@ -149,7 +149,7 @@ jobs:
           PR_HEAD_SHA: ${{ steps.pull_request.outputs.head_sha }}
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const pullRequestNumber = Number(process.env.PR_NUMBER);

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,81 @@
+# Coordinates every pull request check from one immutable merge revision.
+name: Pull Request
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    name: Prepare PR
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ github.sha }}
+      should_run: ${{ steps.changes.outputs.should_run }}
+      has_breaking_label: ${{ steps.metadata.outputs.has_breaking_label }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect code changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          should_run="$(bash scripts/ci-has-code-changes.sh "$BASE_SHA" "$HEAD_SHA")"
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+
+      - name: Capture PR metadata
+        id: metadata
+        env:
+          HAS_BREAKING_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
+        run: echo "has_breaking_label=$HAS_BREAKING_LABEL" >> "$GITHUB_OUTPUT"
+
+  assemble:
+    name: Assemble
+    needs: prepare
+    uses: ./.github/workflows/assemble.yml
+    with:
+      source-sha: ${{ needs.prepare.outputs.source_sha }}
+
+  compile:
+    name: Compile
+    needs: prepare
+    uses: ./.github/workflows/compile.yml
+    with:
+      source-sha: ${{ needs.prepare.outputs.source_sha }}
+
+  lint:
+    name: Lint
+    needs: prepare
+    uses: ./.github/workflows/lint.yml
+    with:
+      should-run: ${{ needs.prepare.outputs.should_run == 'true' }}
+      source-sha: ${{ needs.prepare.outputs.source_sha }}
+
+  test:
+    name: Test
+    needs: prepare
+    uses: ./.github/workflows/test.yml
+    with:
+      should-run: ${{ needs.prepare.outputs.should_run == 'true' }}
+      source-sha: ${{ needs.prepare.outputs.source_sha }}
+
+  api-compatibility:
+    name: Compare Public API Against Release
+    needs: prepare
+    uses: ./.github/workflows/api-compatibility.yml
+    with:
+      has-breaking-label: ${{ needs.prepare.outputs.has_breaking_label == 'true' }}
+      source-sha: ${{ needs.prepare.outputs.source_sha }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,21 +43,21 @@ jobs:
         run: echo "has_breaking_label=$HAS_BREAKING_LABEL" >> "$GITHUB_OUTPUT"
 
   assemble:
-    name: Assemble
+    name: PR Assemble
     needs: prepare
     uses: ./.github/workflows/assemble.yml
     with:
       source-sha: ${{ needs.prepare.outputs.source_sha }}
 
   compile:
-    name: Compile
+    name: PR Compile
     needs: prepare
     uses: ./.github/workflows/compile.yml
     with:
       source-sha: ${{ needs.prepare.outputs.source_sha }}
 
   lint:
-    name: Lint
+    name: PR Lint
     needs: prepare
     uses: ./.github/workflows/lint.yml
     with:
@@ -65,7 +65,7 @@ jobs:
       source-sha: ${{ needs.prepare.outputs.source_sha }}
 
   test:
-    name: Test
+    name: PR Test
     needs: prepare
     uses: ./.github/workflows/test.yml
     with:
@@ -73,7 +73,7 @@ jobs:
       source-sha: ${{ needs.prepare.outputs.source_sha }}
 
   api-compatibility:
-    name: Compare Public API Against Release
+    name: PR Compare Public API Against Release
     needs: prepare
     uses: ./.github/workflows/api-compatibility.yml
     with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,20 @@
-# Workflow: run the charts test suite on pull requests.
-# It uploads a summary artifact and skips work for docs-only changes.
-#
-# This is the main automated test gate for PRs.
+# Reusable charts test suite for pull request orchestration.
 name: Test
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_call:
+    inputs:
+      should-run:
+        description: Whether the pull request contains code or build changes.
+        required: true
+        type: boolean
+      source-sha:
+        description: Immutable merge revision being checked.
+        required: true
+        type: string
 
 permissions:
   contents: read
-
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   test:
@@ -22,15 +24,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Detect code changes
-        id: changes
-        run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          SHOULD_RUN="$(bash scripts/ci-has-code-changes.sh "$BASE_SHA" "$HEAD_SHA")"
-          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+          ref: ${{ inputs.source-sha }}
       - name: Set up JDK 17
-        if: steps.changes.outputs.should_run == 'true'
+        if: ${{ inputs.should-run }}
         uses: actions/setup-java@v5
         with:
           java-version: 17
@@ -38,14 +34,14 @@ jobs:
           cache: gradle
       - name: Test
         id: gradle_tests
-        if: steps.changes.outputs.should_run == 'true'
+        if: ${{ inputs.should-run }}
         run: ./gradlew chartsTest
       - name: Test summary
         if: always()
         continue-on-error: true
         env:
           CI_GRADLE_TEST_OUTCOME: ${{ steps.gradle_tests.outcome }}
-          CI_SHOULD_RUN: ${{ steps.changes.outputs.should_run }}
+          CI_SHOULD_RUN: ${{ inputs.should-run }}
         run: bash scripts/ci-test-summary.sh
       - name: Ensure summary files exist
         if: always()
@@ -54,7 +50,7 @@ jobs:
             CI_TEST_SUMMARY_FORCE_ZERO=true \
             CI_TEST_SUMMARY_SKIP_STEP_SUMMARY=true \
             CI_GRADLE_TEST_OUTCOME="${{ steps.gradle_tests.outcome }}" \
-            CI_SHOULD_RUN="${{ steps.changes.outputs.should_run }}" \
+            CI_SHOULD_RUN="${{ inputs.should-run }}" \
             bash scripts/ci-test-summary.sh
           fi
       - name: Upload test summary artifact
@@ -67,5 +63,5 @@ jobs:
             ci-test-summary.md
             ci-test-summary.json
       - name: Skip tests for docs-only changes
-        if: steps.changes.outputs.should_run != 'true'
+        if: ${{ !inputs.should-run }}
         run: echo "No code/build changes detected. Skipping tests."

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -2,4 +2,5 @@
 
 This directory contains CI workflow diagrams split by flow.
 
+- [Pull Request Orchestration](./pull-request-orchestration.md)
 - [API Compatibility](./api-compatibility.md)

--- a/docs/workflows/pull-request-orchestration.md
+++ b/docs/workflows/pull-request-orchestration.md
@@ -1,0 +1,111 @@
+# Pull Request Orchestration
+
+The pull-request CI is coordinated by
+`.github/workflows/pull-request.yml`. It runs all PR checks against the same
+immutable merge revision. A trusted downstream workflow collects the test
+summary and publishes the report check used as the merge gate.
+
+## Flow
+
+```mermaid
+flowchart TD
+  A["PR opened, updated, reopened, or relabeled"] --> B["Prepare PR"]
+  B --> C["Assemble"]
+  B --> D["Compile"]
+  B --> E["Lint"]
+  B --> F["Test"]
+  B --> G["Compare Public API Against Release"]
+  C --> H["Pull Request workflow completes"]
+  D --> H
+  E --> H
+  F --> H
+  G --> H
+  H --> I["PR Test Summary Comment\n(workflow_run)"]
+  I --> J["PR summary report check"]
+```
+
+`Assemble`, `Compile`, `Lint`, `Test`, and API compatibility run in parallel
+after `Prepare PR`. The parent workflow completes only after all of them have
+finished, and its result reflects any failed, cancelled, or skipped job.
+
+The comment workflow is deliberately downstream and separate. GitHub starts
+`.github/workflows/pr-test-summary-comment.yml` after the `Pull Request`
+workflow completes. After publishing the comment, it reports the stable
+`PR summary report` check on the PR merge commit.
+
+## Workflow responsibilities
+
+| Workflow or job | Responsibility |
+| --- | --- |
+| `Prepare PR` | Checks out the repository, detects code changes, records the merge revision, and reads the `breaking-change` label. |
+| `Assemble` | Runs `./gradlew ciAssemble`. |
+| `Compile` | Runs `./gradlew ciCompile`. |
+| `Lint` | Runs Kotlin and build-logic lint when the PR contains code/build changes. |
+| `Test` | Runs `./gradlew chartsTest` when needed and uploads `ci-test-summary`. Docs-only PRs still upload a skipped summary artifact. |
+| `Compare Public API Against Release` | Runs `./gradlew apiCompatibilityCheck`; a detected breaking change requires the `breaking-change` label. |
+| `PR Test Summary Comment` | Runs with a trusted base-repository token, validates that the PR is still current, creates or updates the summary comment, and publishes the `PR summary report` check. |
+
+The reusable workflows receive `source-sha` from `Prepare PR`, so each check
+uses the same merge result even if a later PR event starts another run. Lint
+and test also receive the shared code-change decision from `Prepare PR`.
+
+## Merge protection
+
+The `protect main` branch ruleset should require only this stable report check:
+
+```text
+PR summary report
+```
+
+The report check is published only after the orchestration succeeds and the
+complete PR comment is created. A missing artifact, failed upstream check,
+failed comment publication, or cancelled orchestration produces a failing
+report check. The individual checks remain visible for diagnosis, but should
+not be required because reusable-workflow check names include caller/callee
+details and would create ruleset maintenance whenever the orchestration changes.
+
+The comment workflow should not be a required check. It runs after the
+orchestrator and is reporting, not validation.
+
+## Fork PR security boundary
+
+The `Pull Request` workflow runs on `pull_request` with read-only repository
+permissions. This is where untrusted PR code is checked out and executed.
+
+The comment workflow runs on `workflow_run`, which gives it the base
+repository token needed to write an issue comment, including for fork PRs. It
+does not check out the PR or execute artifact contents. It only:
+
+1. Resolves the associated open PR.
+2. Verifies that the PR head still matches the completed run.
+3. Downloads the test summary into the runner temporary directory.
+4. Creates or updates the marked summary comment.
+5. Publishes the required `PR summary report` check on the PR merge commit.
+
+If the summary artifact is missing or the parent workflow did not pass, the
+comment is not posted and the required check reports failure.
+
+Do not move build or test steps to `pull_request_target`; that event has write
+access and must not execute untrusted PR code.
+
+## Docs-only changes
+
+`scripts/ci-has-code-changes.sh` treats documentation and release-note-only
+changes as non-code changes. Lint and test steps are skipped in that case, but
+the jobs still finish successfully and the test workflow uploads a skipped
+summary. Assemble and compile continue to run as lightweight build checks.
+
+## Troubleshooting
+
+- **The PR cannot merge:** inspect the required status-check names in the
+  `protect main` ruleset. Reusable workflows can expose check names differently
+  after the first rollout, so use the exact names shown on the PR checks page.
+- **The comment is missing:** inspect the `PR Test Summary Comment` run. It
+  skips stale or closed PRs and requires the test summary artifact from the
+  triggering run.
+- **The PR summary report check is red:** the summary artifact was not
+  available or the comment could not be posted. See the workflow run for
+  details.
+- **API compatibility fails:** add the `breaking-change` label only when the
+  API break is intentional; unrelated Gradle or compatibility errors are not
+  bypassed by the label.


### PR DESCRIPTION
Convert existing CI workflows to reusable workflows and introduce a new pull-request.yml orchestrator. All checks run against the same immutable merge revision, and the test summary comment workflow uses workflow_run to preserve fork PR security boundaries.