### PR TITLE
fix(ci): authenticate PR summary artifact download

### DIFF
--- a/.github/workflows/pr-test-summary-comment.yml
+++ b/.github/workflows/pr-test-summary-comment.yml
@@ -93,6 +93,7 @@ jobs:
           name: ci-test-summary
           path: ${{ runner.temp }}/ci-summary
           run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create or update PR comment
         id: publish_comment


### PR DESCRIPTION
## Why

The downstream PR summary workflow could not download the test-summary artifact from the completed Pull Request workflow, leaving the required `PR summary report` check red even when all build checks passed.

## Summary

Supplies the workflow token to the cross-workflow artifact download action. This allows the summary comment and stable required check to be published after successful PR validation.

## Changes

- Authenticate the PR summary artifact download with `GITHUB_TOKEN`.

## Release/Changeset

- Not required (technical/internal-only)

## Notes/Risk

- Low risk: the workflow already has `actions: read` permission; this enables the existing artifact access path.