### PR TITLE
chore(web): migrate playground to Wasm

### DIFF
--- a/.github/workflows/publish-static-assets.yml
+++ b/.github/workflows/publish-static-assets.yml
@@ -168,7 +168,7 @@ jobs:
           set -euo pipefail
           PUBLISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           PLAYGROUND_SHA="$(git rev-parse HEAD)"
-          ./gradlew -DchartsLocalPath=.. :playground:jsBrowserDevelopmentExecutableDistribution \
+          ./gradlew -DchartsLocalPath=.. :playground:wasmJsBrowserDistribution \
             -PsnapshotMetadataChartsSha="${SOURCE_SHA}" \
             -PsnapshotMetadataPlaygroundSha="${PLAYGROUND_SHA}" \
             -PsnapshotMetadataChartsVersion="${CHARTS_VERSION}" \
@@ -180,8 +180,8 @@ jobs:
         run: |
           set -euo pipefail
           required_files=(
-            playground/build/dist/js/developmentExecutable/index.html
-            playground/build/dist/js/developmentExecutable/Playground.js
+            playground/build/dist/wasmJs/productionExecutable/index.html
+            playground/build/dist/wasmJs/productionExecutable/Playground.js
           )
           for file in "${required_files[@]}"; do
             if [[ ! -f "${file}" ]]; then
@@ -200,7 +200,7 @@ jobs:
           CHARTS_VERSION: ${{ inputs.charts-version }}
           SOURCE_SHA: ${{ inputs.source-sha }}
           DOCS_STATIC_BUCKET: ${{ vars.DOCS_STATIC_BUCKET }}
-          PLAYGROUND_DIST_DIR: playground/build/dist/js/developmentExecutable
+          PLAYGROUND_DIST_DIR: playground/build/dist/wasmJs/productionExecutable
         shell: bash
         run: bash ../.github/scripts/publish-docs-to-s3.sh snapshot playground
 

--- a/release-notes/2.4.0/changes/489-wasm-playground.md
+++ b/release-notes/2.4.0/changes/489-wasm-playground.md
@@ -1,0 +1,6 @@
+# PR Changeset
+
+- type: `chore`
+- module: `charts`
+- pr: `https://github.com/HDCharts/charts/pull/489`
+- release_note: `The web playground now uses the optimized WebAssembly production pipeline.`


### PR DESCRIPTION
## Why

The playground was still deployed from a Kotlin/JS development build, while the charts demo now uses the optimized Wasm pipeline.

## Summary

This migrates the web playground to Compose Multiplatform Wasm and updates the shared static-asset workflow to publish its optimized production distribution. The playground keeps JVM tests and moves browser tests to Wasm, with clipboard support using Compose's multiplatform API.

## Changes

- Migrate playground sources and tests from JS to Wasm.
- Publish `wasmJsBrowserDistribution` artifacts to the playground S3 prefix.
- Update CI compile, assemble, test-summary, and validation paths.
- Replace dynamic browser clipboard interop with Compose clipboard APIs.

## Release/Changeset

- Created: `release-notes/2.4.0/changes/489-wasm-playground.md`

## Related PRs

- `charts-playground`: https://github.com/HDCharts/charts-playground/pull/23

## Notes/Risk

- Browser and S3 acceptance will be verified manually after deployment.