### PR TITLE
Skip validation jobs for docs-only PRs

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -8,6 +8,10 @@ on:
         description: Whether the pull request has the breaking-change label.
         required: true
         type: boolean
+      should-run:
+        description: Whether the pull request contains code or build changes.
+        required: true
+        type: boolean
       source-sha:
         description: Immutable merge revision being checked.
         required: true
@@ -19,6 +23,7 @@ permissions:
 jobs:
   api-compatibility:
     name: Compare Public API Against Release
+    if: ${{ inputs.should-run }}
     runs-on: ubuntu-latest
     env:
       HAS_BREAKING_LABEL: ${{ inputs.has-breaking-label }}

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -4,6 +4,10 @@ name: Assemble
 on:
   workflow_call:
     inputs:
+      should-run:
+        description: Whether the pull request contains code or build changes.
+        required: true
+        type: boolean
       source-sha:
         description: Immutable merge revision being checked.
         required: true
@@ -15,6 +19,7 @@ permissions:
 jobs:
   assemble:
     name: Assemble
+    if: ${{ inputs.should-run }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -4,6 +4,10 @@ name: Compile
 on:
   workflow_call:
     inputs:
+      should-run:
+        description: Whether the pull request contains code or build changes.
+        required: true
+        type: boolean
       source-sha:
         description: Immutable merge revision being checked.
         required: true
@@ -15,6 +19,7 @@ permissions:
 jobs:
   compile:
     name: Compile
+    if: ${{ inputs.should-run }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   lint:
     name: Lint
+    if: ${{ inputs.should-run }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -26,15 +27,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.source-sha }}
       - name: Set up JDK 17
-        if: ${{ inputs.should-run }}
         uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'
           cache: gradle
       - name: Lint
-        if: ${{ inputs.should-run }}
         run: ./gradlew ktlintCheck buildSrcKtlintCheck
-      - name: Skip lint for docs-only changes
-        if: ${{ !inputs.should-run }}
-        run: echo "No code/build changes detected. Skipping lint."

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,6 +47,7 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/assemble.yml
     with:
+      should-run: ${{ needs.prepare.outputs.should_run == 'true' }}
       source-sha: ${{ needs.prepare.outputs.source_sha }}
 
   compile:
@@ -54,6 +55,7 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/compile.yml
     with:
+      should-run: ${{ needs.prepare.outputs.should_run == 'true' }}
       source-sha: ${{ needs.prepare.outputs.source_sha }}
 
   lint:
@@ -78,4 +80,5 @@ jobs:
     uses: ./.github/workflows/api-compatibility.yml
     with:
       has-breaking-label: ${{ needs.prepare.outputs.has_breaking_label == 'true' }}
+      should-run: ${{ needs.prepare.outputs.should_run == 'true' }}
       source-sha: ${{ needs.prepare.outputs.source_sha }}

--- a/docs/workflows/pull-request-orchestration.md
+++ b/docs/workflows/pull-request-orchestration.md
@@ -42,8 +42,9 @@ the exact scope invoked by the reusable workflows. The `smoke-line` consumer
 compile belongs only to `ciCompile`, not to a test task.
 
 The reusable workflows receive `source-sha` from `Prepare PR`, so each check
-uses the same merge result even if a later PR event starts another run. Lint
-and test also receive the shared code-change decision from `Prepare PR`.
+uses the same merge result even if a later PR event starts another run. Every
+validation workflow also receives the shared code-change decision from
+`Prepare PR` and skips its job when the change is documentation-only.
 
 ## Merge protection
 
@@ -74,9 +75,9 @@ access and must not execute untrusted PR code.
 ## Docs-only changes
 
 `scripts/ci-has-code-changes.sh` treats documentation and release-note-only
-changes as non-code changes. Lint and test steps are skipped in that case, but
-the jobs still finish successfully. Assemble and compile continue to run as
-lightweight build checks.
+changes as non-code changes. `Prepare PR` still runs, while the assemble,
+compile, lint, test, and API compatibility jobs are skipped before their
+runners start. Their required checks report success as skipped jobs.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Skip assemble, compile, lint, test, and API compatibility jobs for documentation-only pull requests while keeping required checks successful.