### PR TITLE
chore: remove obsolete playground version metadata

### DIFF
--- a/.github/workflows/publish-static-assets.yml
+++ b/.github/workflows/publish-static-assets.yml
@@ -163,7 +163,6 @@ jobs:
         shell: bash
         env:
           SOURCE_SHA: ${{ inputs.source-sha }}
-          CHARTS_VERSION: ${{ inputs.charts-version }}
         run: |
           set -euo pipefail
           PUBLISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -171,7 +170,6 @@ jobs:
           ./gradlew -DchartsLocalPath=.. :playground:wasmJsBrowserDistribution \
             -PsnapshotMetadataChartsSha="${SOURCE_SHA}" \
             -PsnapshotMetadataPlaygroundSha="${PLAYGROUND_SHA}" \
-            -PsnapshotMetadataChartsVersion="${CHARTS_VERSION}" \
             -PsnapshotMetadataPublishedAt="${PUBLISHED_AT}" \
             --no-daemon --stacktrace --build-cache
       - name: Validate playground static assets


### PR DESCRIPTION
## Summary
- remove the unused `CHARTS_VERSION` build-step environment variable for playground
- stop passing the removed `snapshotMetadataChartsVersion` Gradle property

The playground now reads its display version from the checked-in charts `.version` file. The publication workflow still passes `charts-version` where API, demo, and S3 publication metadata require it.

## Validation
- `git diff --check`