### PR TITLE
ci: split pull request validation workflows

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -21,6 +21,14 @@ permissions:
   contents: read
 
 jobs:
+  skipped:
+    name: Skipped (no code changes)
+    if: ${{ !inputs.should-run }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report skipped API compatibility
+        run: echo 'No code changes require the API compatibility check.'
+
   api-compatibility:
     name: Compare Public API Against Release
     if: ${{ inputs.should-run }}

--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -22,11 +22,11 @@ permissions:
 
 jobs:
   skipped:
-    name: Skipped (no code changes)
+    name: Docs-only no-op
     if: ${{ !inputs.should-run }}
     runs-on: ubuntu-latest
     steps:
-      - name: Report skipped API compatibility
+      - name: Report docs-only no-op
         run: echo 'No code changes require the API compatibility check.'
 
   api-compatibility:

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -18,11 +18,11 @@ permissions:
 
 jobs:
   skipped:
-    name: Skipped (no code changes)
+    name: Docs-only no-op
     if: ${{ !inputs.should-run }}
     runs-on: ubuntu-latest
     steps:
-      - name: Report skipped assemble
+      - name: Report docs-only no-op
         run: echo 'No code changes require the assemble check.'
 
   assemble:

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -17,6 +17,14 @@ permissions:
   contents: read
 
 jobs:
+  skipped:
+    name: Skipped (no code changes)
+    if: ${{ !inputs.should-run }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report skipped assemble
+        run: echo 'No code changes require the assemble check.'
+
   assemble:
     name: Assemble
     if: ${{ inputs.should-run }}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -17,6 +17,14 @@ permissions:
   contents: read
 
 jobs:
+  skipped:
+    name: Skipped (no code changes)
+    if: ${{ !inputs.should-run }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report skipped compile
+        run: echo 'No code changes require the compile check.'
+
   compile:
     name: Compile
     if: ${{ inputs.should-run }}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -18,11 +18,11 @@ permissions:
 
 jobs:
   skipped:
-    name: Skipped (no code changes)
+    name: Docs-only no-op
     if: ${{ !inputs.should-run }}
     runs-on: ubuntu-latest
     steps:
-      - name: Report skipped compile
+      - name: Report docs-only no-op
         run: echo 'No code changes require the compile check.'
 
   compile:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,14 @@ permissions:
   contents: read
 
 jobs:
+  skipped:
+    name: Skipped (no code changes)
+    if: ${{ !inputs.should-run }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report skipped lint
+        run: echo 'No code changes require the lint check.'
+
   lint:
     name: Lint
     if: ${{ inputs.should-run }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,11 +18,11 @@ permissions:
 
 jobs:
   skipped:
-    name: Skipped (no code changes)
+    name: Docs-only no-op
     if: ${{ !inputs.should-run }}
     runs-on: ubuntu-latest
     steps:
-      - name: Report skipped lint
+      - name: Report docs-only no-op
         run: echo 'No code changes require the lint check.'
 
   lint:

--- a/.github/workflows/pull-request-api.yml
+++ b/.github/workflows/pull-request-api.yml
@@ -1,0 +1,102 @@
+# Coordinates public API compatibility checks for pull requests.
+name: Pull Request API Compatibility
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: >-
+    ${{
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'reopened' ||
+        (
+          (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+          github.event.label.name == 'breaking-change'
+        )
+      ) &&
+      format('pr-api-{0}', github.event.pull_request.number) ||
+      format('pr-api-ignored-{0}', github.run_id)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  prepare-api:
+    name: Prepare API Compatibility
+    if: >-
+      ${{
+        github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'reopened' ||
+        (
+          (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+          github.event.label.name == 'breaking-change'
+        )
+      }}
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.changes.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect code changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          should_run="$(bash scripts/ci-has-code-changes.sh "$BASE_SHA" "$HEAD_SHA")"
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+
+  api-compatibility:
+    name: Internal API Compatibility
+    needs: prepare-api
+    uses: ./.github/workflows/api-compatibility.yml
+    with:
+      has-breaking-label: ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
+      should-run: >-
+        ${{
+          needs.prepare-api.outputs.should_run == 'true' ||
+          (
+            (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+            github.event.label.name == 'breaking-change'
+          )
+        }}
+      source-sha: ${{ github.sha }}
+
+  api-result:
+    name: >-
+      ${{
+          needs.prepare-api.result != 'skipped' &&
+          'PR API Compatibility' ||
+          'API compatibility not requested'
+      }}
+    if: ${{ always() && needs.prepare-api.result != 'skipped' }}
+    needs:
+      - prepare-api
+      - api-compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify API compatibility
+        env:
+          PREPARE_RESULT: ${{ needs.prepare-api.result }}
+          API_RESULT: ${{ needs.api-compatibility.result }}
+        run: |
+          for result in \
+            "$PREPARE_RESULT" \
+            "$API_RESULT"
+          do
+            if [ "$result" != "success" ]; then
+              echo "A required API check did not succeed: $result"
+              exit 1
+            fi
+          done

--- a/.github/workflows/pull-request-gif-validation.yml
+++ b/.github/workflows/pull-request-gif-validation.yml
@@ -1,0 +1,57 @@
+# Coordinates opt-in GIF baseline validation for pull requests.
+name: Pull Request GIF Validation
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: >-
+    ${{
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'reopened' ||
+        (
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'run-gif-validation'
+        ) ||
+        (
+          github.event.action == 'unlabeled' &&
+          github.event.label.name == 'run-gif-validation'
+        )
+      ) &&
+      format('pr-gif-{0}', github.event.pull_request.number) ||
+      format('pr-gif-ignored-{0}', github.run_id)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  gif-validation:
+    # Optional: keep this out of the required-status-check ruleset.
+    name: PR GIF Baseline Validation
+    if: >-
+      ${{
+        (
+          (
+            github.event.action == 'opened' ||
+            github.event.action == 'synchronize' ||
+            github.event.action == 'reopened'
+          ) &&
+          contains(github.event.pull_request.labels.*.name, 'run-gif-validation')
+        ) ||
+        (
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'run-gif-validation' &&
+          contains(github.event.pull_request.labels.*.name, 'run-gif-validation')
+        )
+      }}
+    uses: ./.github/workflows/validate-gifs.yml
+    with:
+      should-run: true
+      source-sha: ${{ github.sha }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,17 +1,17 @@
-# Coordinates every pull request check from one immutable merge revision.
+# Coordinates core pull request checks from one immutable merge revision.
 name: Pull Request
 
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 permissions:
   actions: read
   contents: read
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}
+  group: pr-core-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -21,8 +21,6 @@ jobs:
     outputs:
       source_sha: ${{ github.sha }}
       should_run: ${{ steps.changes.outputs.should_run }}
-      should_run_gif_validation: ${{ steps.metadata.outputs.should_run_gif_validation }}
-      has_breaking_label: ${{ steps.metadata.outputs.has_breaking_label }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -38,17 +36,6 @@ jobs:
           echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
           bash .github/scripts/sync-gif-baselines.sh --self-test
           bash .github/scripts/validate-snapshot-provenance.sh --self-test
-
-      - name: Capture PR metadata and GIF validation request
-        id: metadata
-        env:
-          HAS_BREAKING_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
-          RUN_GIF_VALIDATION: ${{ contains(github.event.pull_request.labels.*.name, 'run-gif-validation') }}
-        run: |
-          {
-            printf 'has_breaking_label=%s\n' "$HAS_BREAKING_LABEL"
-            printf 'should_run_gif_validation=%s\n' "$RUN_GIF_VALIDATION"
-          } >> "$GITHUB_OUTPUT"
 
   assemble:
     name: PR Assemble
@@ -82,19 +69,34 @@ jobs:
       should-run: ${{ needs.prepare.outputs.should_run == 'true' }}
       source-sha: ${{ needs.prepare.outputs.source_sha }}
 
-  api-compatibility:
-    name: PR Compare Public API Against Release
-    needs: prepare
-    uses: ./.github/workflows/api-compatibility.yml
-    with:
-      has-breaking-label: ${{ needs.prepare.outputs.has_breaking_label == 'true' }}
-      should-run: ${{ needs.prepare.outputs.should_run == 'true' }}
-      source-sha: ${{ needs.prepare.outputs.source_sha }}
-
-  gif-validation:
-    name: PR GIF Baseline Validation
-    needs: prepare
-    uses: ./.github/workflows/validate-gifs.yml
-    with:
-      should-run: ${{ needs.prepare.outputs.should_run_gif_validation == 'true' }}
-      source-sha: ${{ needs.prepare.outputs.source_sha }}
+  core-result:
+    name: PR Core Checks
+    if: ${{ always() }}
+    needs:
+      - prepare
+      - assemble
+      - compile
+      - lint
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify core checks
+        env:
+          PREPARE_RESULT: ${{ needs.prepare.result }}
+          ASSEMBLE_RESULT: ${{ needs.assemble.result }}
+          COMPILE_RESULT: ${{ needs.compile.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          for result in \
+            "$PREPARE_RESULT" \
+            "$ASSEMBLE_RESULT" \
+            "$COMPILE_RESULT" \
+            "$LINT_RESULT" \
+            "$TEST_RESULT"
+          do
+            if [ "$result" != "success" ]; then
+              echo "A required core check did not succeed: $result"
+              exit 1
+            fi
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,14 @@ permissions:
   contents: read
 
 jobs:
+  skipped:
+    name: Skipped (no code changes)
+    if: ${{ !inputs.should-run }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report skipped tests
+        run: echo 'No code changes require the test suite.'
+
   jvm-tests:
     name: JVM Tests
     if: ${{ inputs.should-run }}
@@ -150,4 +158,3 @@ jobs:
           path: |
             **/build/reports/iosSimulatorArm64Test/**
             **/build/test-results/iosSimulatorArm64Test/**
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,11 @@ permissions:
 
 jobs:
   skipped:
-    name: Skipped (no code changes)
+    name: Docs-only no-op
     if: ${{ !inputs.should-run }}
     runs-on: ubuntu-latest
     steps:
-      - name: Report skipped tests
+      - name: Report docs-only no-op
         run: echo 'No code changes require the test suite.'
 
   jvm-tests:

--- a/docs/workflows/api-compatibility.md
+++ b/docs/workflows/api-compatibility.md
@@ -28,6 +28,12 @@ allocate an API runner. The reusable `API Compatibility` workflow runs the
 Gradle check when the pull request contains code/build changes or when a
 `breaking-change` label event forces the check.
 
+The reusable workflow exposes both the real compatibility job and a
+`Docs-only no-op` job. GitHub displays the inactive job as
+skipped even when the real compatibility job is running. That row is only the
+unselected alternative; it does not mean that this pull request lacks code
+changes.
+
 If a breaking change is acknowledged with the `breaking-change` label and
 merged, the post-merge baseline update flow below runs automatically.
 

--- a/docs/workflows/api-compatibility.md
+++ b/docs/workflows/api-compatibility.md
@@ -1,25 +1,35 @@
 # API Compatibility
 
 Workflows:
-- `API Compatibility` — `charts/.github/workflows/api-compatibility.yml`
+- `Pull Request API Compatibility` — `charts/.github/workflows/pull-request-api.yml` (pull-request orchestration)
+- `API Compatibility` — `charts/.github/workflows/api-compatibility.yml` (reusable compatibility check)
 - `Set API Baseline` — `charts/.github/workflows/set-api-baseline.yml` (post-merge baseline update)
 
 ## PR Compatibility Flow
 
 ```mermaid
 flowchart TD
-  A["Contributor opens or updates PR to main"] --> B["Run API Compatibility (charts/.github/workflows/api-compatibility.yml)"]
-  B --> C{"Breaking API change detected?"}
-  C -- No --> D["Pass: API remains compatible"]
-  C -- Yes --> E{"PR has breaking-change label?"}
-  E -- No --> F["Fail: add label or restore compatibility"]
-  E -- Yes --> G["Pass: breaking change is explicitly acknowledged"]
+  A["PR opened, synchronized, or reopened"] --> B["Pull Request API Compatibility"]
+  L["breaking-change label added or removed"] --> B
+  B --> C["Run API Compatibility when required"]
+  C --> D{"Breaking API change detected?"}
+  D -- No --> E["Pass: API remains compatible"]
+  D -- Yes --> F{"PR has breaking-change label?"}
+  F -- No --> G["Fail: add breaking-change label or restore compatibility"]
+  F -- Yes --> H["Pass: breaking change is explicitly acknowledged"]
 
-  F --> B
+  G --> B
 ```
 
-If a breaking change is acknowledged and merged, the post-merge baseline update
-flow below runs automatically.
+The `Pull Request API Compatibility` workflow runs for the `opened`,
+`synchronize`, and `reopened` pull-request actions. It also runs when the
+`breaking-change` label is added or removed. Events for other labels do not
+allocate an API runner. The reusable `API Compatibility` workflow runs the
+Gradle check when the pull request contains code/build changes or when a
+`breaking-change` label event forces the check.
+
+If a breaking change is acknowledged with the `breaking-change` label and
+merged, the post-merge baseline update flow below runs automatically.
 
 ## Release Audit Flow
 
@@ -45,7 +55,7 @@ Example for a `2.3.0` release whose previous release is `2.2.0`:
 
 ```mermaid
 flowchart TD
-  A["Breaking-change PR is merged to main"] --> B["Set API Baseline runs automatically"]
+  A["PR with the breaking-change label is merged to main"] --> B["Set API Baseline runs automatically"]
   B --> C["Use the merge commit as the immutable baseline"]
   C --> D["Workflow creates baseline-update PR"]
   D --> E["Review and merge baseline-update PR"]

--- a/docs/workflows/pull-request-orchestration.md
+++ b/docs/workflows/pull-request-orchestration.md
@@ -1,73 +1,108 @@
 # Pull Request Orchestration
 
-The pull-request CI is coordinated by
-`.github/workflows/pull-request.yml`. It runs all PR checks against the same
-immutable merge revision.
+Pull-request CI is split into three independently triggered workflows: core
+checks, API compatibility, and optional GIF validation. Core checks and API
+compatibility use separate concurrency groups so events for one label cannot
+cancel unrelated work. Each workflow uses the immutable `github.sha` for the
+pull-request event that started it.
+
+## Labels
+
+- `breaking-change` marks an intentional public API incompatibility. Adding or
+  removing this label runs API compatibility, even when the pull request only
+  changes documentation or release notes. The label does not start or cancel
+  core checks.
+- `run-gif-validation` opts a pull request into GIF baseline validation. The
+  validation runs for normal pull-request events while this label is present,
+  starts when the label is added, and is cancelled when the label is removed.
+  It is informational and is not a required status check.
 
 ## Flow
 
 ```mermaid
 flowchart TD
-  A["PR opened, updated, reopened, or relabeled"] --> B["Prepare PR"]
-  B --> C["Assemble"]
-  B --> D["Compile"]
-  B --> E["Lint"]
-  B --> F["Test"]
-  B --> G["Compare Public API Against Release"]
-  C --> H["Pull Request workflow completes"]
-  D --> H
-  E --> H
-  F --> H
-  G --> H
+  A["PR opened, synchronized, or reopened"] --> B["Core workflow"]
+  B --> C["Assemble, Compile, Lint, Test"]
+  C --> D["PR Core Checks"]
+  A --> E["API workflow"]
+  E --> F["API compatibility"]
+  F --> G["PR API Compatibility"]
+  A --> H{"run-gif-validation label present?"}
+  H -- Yes --> I["GIF validation"]
 ```
 
-`Assemble`, `Compile`, `Lint`, `Test`, and API compatibility run in parallel
-after `Prepare PR`. The parent workflow completes only after all of them have
-finished, and its result reflects any failed, cancelled, or skipped job.
+The core workflow runs only for the `opened`, `synchronize`, and `reopened`
+pull-request actions. Its `PR Core Checks` gate fails if preparation or any
+dependent core check fails or is cancelled. Documentation-only changes still
+use the reusable workflows' successful no-op path.
+
+The API workflow listens for the same three pull-request actions plus
+`labeled` and `unlabeled`. For label actions, only an event for the
+`breaking-change` label is relevant. Events for other labels skip `Prepare API
+Compatibility` before a runner is allocated. The API result gate derives its
+required name and execution eligibility from that preparation result rather
+than repeating the event expression.
+
+The GIF workflow is optional. It runs on the three normal pull-request actions
+only when the `run-gif-validation` label is present, or when that label is
+added. Its `pr-gif-<PR number>` concurrency group cancels an active validation
+when the `run-gif-validation` label is removed; the removal event itself does
+not start a new validation.
 
 ## Workflow responsibilities
 
 | Workflow or job | Responsibility |
 | --- | --- |
-| `Prepare PR` | Checks out the repository, detects code changes, records the merge revision, and reads the `breaking-change` label. |
+| `Prepare PR` | Checks out the repository, detects code changes, and records the merge revision for core checks. |
 | `Assemble` | Runs `./gradlew ciAssemble`. |
 | `Compile` | Runs `./gradlew ciCompile`. |
 | `Lint` | Runs Kotlin and build-logic lint when the PR contains code/build changes. |
 | `Test` | Runs `ciTestJvm`, `ciTestAndroid`, `ciTestWeb`, and `ciTestIos` when needed; uploads Gradle's native HTML and XML reports. |
-| `Compare Public API Against Release` | Runs `./gradlew apiCompatibilityCheck`; a detected breaking change requires the `breaking-change` label. |
+| `Prepare API Compatibility` | Routes normal pull-request actions and changes to the `breaking-change` label, detects code changes, and prevents events for other labels from allocating a runner. |
+| `API compatibility` | Runs `./gradlew apiCompatibilityCheck`; a detected public API incompatibility requires the `breaking-change` label. |
+| `GIF validation` | Runs the opt-in GIF baseline workflow while the `run-gif-validation` label is present. |
 
 Gradle's `chartsTest*` tasks are platform-specific commands for local use. The
 `ciTest*`, `ciCompile`, and `ciAssemble` tasks are CI entry points; they define
 the exact scope invoked by the reusable workflows. The `smoke-line` consumer
 compile belongs only to `ciCompile`, not to a test task.
 
-The reusable workflows receive `source-sha` from `Prepare PR`, so each check
-uses the same merge result even if a later PR event starts another run. Every
-validation workflow also receives the shared code-change decision from
-`Prepare PR` and skips its job when the change is documentation-only.
+The core reusable workflows receive `source-sha` from `Prepare PR`. API and
+GIF validation receive the triggering event's `github.sha`, so each check uses
+the immutable merge result for that event. Core and API workflows retain their
+code-change optimization, while changes to the `breaking-change` label force
+API compatibility even when no code change is detected.
+
+The repeated API event condition is intentional in only these places:
+
+- `concurrency.group`: relevant API events share `pr-api-<PR number>` and
+  events for other labels receive an isolated group.
+- `prepare-api.if`: events for other labels do not allocate an API runner.
+- the `api-compatibility` reusable-workflow `should-run` input: adding or
+  removing `breaking-change` forces the compatibility check.
+
+Downstream API jobs use `needs.prepare-api.result` instead of repeating the
+event condition.
 
 ## Merge protection
 
-The `protect main` branch ruleset should require the validation checks:
+The `protect main` branch ruleset requires only these stable final gates:
 
 ```text
-PR Assemble / Assemble
-PR Compile / Compile
-PR Lint / Lint
-PR Test / JVM Tests
-PR Test / Android Tests
-PR Test / Wasm Tests
-PR Test / iOS Tests
-PR Compare Public API Against Release / Compare Public API Against Release
+PR Core Checks
+PR API Compatibility
 ```
 
-These checks directly represent the work that protects the branch. Reporting
-and artifact publication are informational and must not be merge gates.
+Do not require `Prepare PR`, `Prepare API Compatibility`, individual
+implementation jobs, or `PR GIF Baseline Validation`; GIF validation is
+optional. Rulesets match status-check contexts literally, so keep the required
+names exactly as shown above.
 
 ## Fork PR security boundary
 
-The `Pull Request` workflow runs on `pull_request` with read-only repository
-permissions. This is where untrusted PR code is checked out and executed.
+All three pull-request workflows run on `pull_request` with read-only
+repository permissions. This is where untrusted PR code is checked out and
+executed.
 
 Do not move build or test steps to `pull_request_target`; that event has write
 access and must not execute untrusted PR code.
@@ -75,9 +110,12 @@ access and must not execute untrusted PR code.
 ## Docs-only changes
 
 `scripts/ci-has-code-changes.sh` treats documentation and release-note-only
-changes as non-code changes. `Prepare PR` still runs, while the assemble,
-compile, lint, test, and API compatibility jobs are skipped before their
-runners start. Their required checks report success as skipped jobs.
+changes as non-code changes. For the normal `opened`, `synchronize`, and
+`reopened` actions, `Prepare PR` and `Prepare API Compatibility` run, while the
+core and API reusable workflows take their successful no-op paths. A
+`breaking-change` label addition or removal is the exception: it forces API
+compatibility even for a docs-only pull request. Events for other labels skip
+API preparation and do not allocate an API runner.
 
 ## Troubleshooting
 
@@ -85,6 +123,6 @@ runners start. Their required checks report success as skipped jobs.
   `protect main` ruleset. Reusable workflows can expose check names differently
   after the first rollout, so use the exact names shown on the PR checks page.
 - **Tests fail:** inspect the relevant `PR Test` job logs (JVM, Android, Wasm, or iOS) and download its test-report artifact for Gradle's HTML and XML reports.
-- **API compatibility fails:** add the `breaking-change` label only when the
-  API break is intentional; unrelated Gradle or compatibility errors are not
-  bypassed by the label.
+- **API compatibility fails:** add the `breaking-change` label only when a
+  detected public API incompatibility is intentional; unrelated Gradle or
+  compatibility errors are not bypassed by this label.

--- a/docs/workflows/pull-request-orchestration.md
+++ b/docs/workflows/pull-request-orchestration.md
@@ -117,6 +117,29 @@ core and API reusable workflows take their successful no-op paths. A
 compatibility even for a docs-only pull request. Events for other labels skip
 API preparation and do not allocate an API runner.
 
+## Reusable workflow status display
+
+The reusable core and API workflows define two mutually exclusive paths for
+some checks:
+
+- the real validation job, such as `Assemble` or `Compare Public API Against
+  Release`;
+- an explicit docs-only no-op job named `Docs-only no-op`.
+
+GitHub displays both job definitions in the run, even though only one path is
+selected. Therefore, a code-changing pull request can show
+`Docs-only no-op` while the real validation job is running and
+passing. That skipped row is the inactive alternative; it does not mean that
+the pull request had no code changes and is not an additional required check.
+
+For a docs-only pull request, the no-op job succeeds and the real validation
+job is skipped. The aggregate `PR Core Checks` and `PR API Compatibility` jobs
+then verify the result of the selected path.
+
+The optional `PR GIF Baseline Validation` job is different: when it is skipped,
+the `run-gif-validation` label was not present and GIF validation was not
+requested.
+
 ## Troubleshooting
 
 - **The PR cannot merge:** inspect the required status-check names in the


### PR DESCRIPTION
## Why

The pull-request workflow coupled core checks, API compatibility, and optional GIF validation, which made label-triggered runs cancel unrelated work and made required check handling less stable.

## Summary

This PR separates core, API compatibility, and optional GIF validation into independent workflows. It preserves successful no-op behavior for docs-only changes while keeping stable aggregate checks for branch protection. The orchestration and API compatibility documentation now describe the exact labels and event behavior.

## Changes

- Split API compatibility and optional GIF validation into dedicated pull-request workflows.
- Keep `PR Core Checks` and `PR API Compatibility` as the stable required gates.
- Route `breaking-change` label changes through API compatibility without starting core checks.
- Clarify label behavior, docs-only exceptions, security boundaries, and reusable workflow responsibilities.

## Release/Changeset

- Not required

## Notes/Risk

- The `protect main` ruleset has been updated separately to require the two stable aggregate checks.
- Workflow YAML parsing, CI self-tests, and `git diff --check` passed locally.