### PR TITLE
ci: pass chartsDisplayVersion to playground snapshot build

### DIFF
--- a/.github/workflows/publish-static-assets.yml
+++ b/.github/workflows/publish-static-assets.yml
@@ -167,7 +167,8 @@ jobs:
           set -euo pipefail
           PUBLISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           PLAYGROUND_SHA="$(git rev-parse HEAD)"
-          ./gradlew -DchartsLocalPath=.. :playground:wasmJsBrowserDistribution \
+          ./gradlew :playground:wasmJsBrowserDistribution \
+            -PchartsDisplayVersion="${{ inputs.charts-version }}" \
             -PsnapshotMetadataChartsSha="${SOURCE_SHA}" \
             -PsnapshotMetadataPlaygroundSha="${PLAYGROUND_SHA}" \
             -PsnapshotMetadataPublishedAt="${PUBLISHED_AT}" \


### PR DESCRIPTION
## Summary
Follow-up to HDCharts/charts-playground#30. The playground build no longer reads the removed `.version` file, so the snapshot workflow must supply the version explicitly.

- Pass `-PchartsDisplayVersion="${{ inputs.charts-version }}"` to the playground `wasmJsBrowserDistribution` task, reusing the same resolved version already passed to the demo and API reference jobs.
- Dropped the now-unused `-DchartsLocalPath=..` flag.