### PR TITLE
ci: restore -DchartsLocalPath=.. for playground build

### DIFF
--- a/.github/workflows/publish-static-assets.yml
+++ b/.github/workflows/publish-static-assets.yml
@@ -167,7 +167,7 @@ jobs:
           set -euo pipefail
           PUBLISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           PLAYGROUND_SHA="$(git rev-parse HEAD)"
-          ./gradlew :playground:wasmJsBrowserDistribution \
+          ./gradlew -DchartsLocalPath=.. :playground:wasmJsBrowserDistribution \
             -PchartsDisplayVersion="${{ inputs.charts-version }}" \
             -PsnapshotMetadataChartsSha="${SOURCE_SHA}" \
             -PsnapshotMetadataPlaygroundSha="${PLAYGROUND_SHA}" \


### PR DESCRIPTION
## Summary
PR #504 removed `-DchartsLocalPath=..` from the playground snapshot build, assuming it was unused. It is still required: `playground/settings.gradle.kts` uses the `chartsLocalPath` system property to `includeBuild` the local charts checkout for `charts`/`charts-demo-shared` dependency substitution. Its default `../charts` is wrong for the CI layout (playground is checked out inside the charts checkout), so without the override the build fails with:

> charts repo not found at '../charts'. Provide -DchartsLocalPath=<path-to-charts>.

Restore `-DchartsLocalPath=..` alongside the `-PchartsDisplayVersion` we now pass.

## Test plan
- Nightly "Publish playground" should now pass `settings.gradle.kts` and build successfully, unblocking the snapshot chain.