### PR TITLE
Add checkout step to announce jobs for local composite actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,9 @@ jobs:
     needs: [prepare-release, publish-maven, promote-docs, verify-docs-deployment]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
       - name: Publish GitHub release with highlights
         id: publish
         uses: ./.github/actions/publish-github-release

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -251,6 +251,9 @@ jobs:
     if: ${{ needs.prepare-snapshot.outputs.is_snapshot == 'true' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
       - name: Publish GitHub prerelease with highlights
         id: publish
         uses: ./.github/actions/publish-github-prerelease


### PR DESCRIPTION
Adds actions/checkout@v7 with fetch-depth: 1 to the announce-release and announce-snapshot jobs so that local composite actions (publish-github-release and publish-github-prerelease) can locate their action.yml definitions.