### PR TITLE
Remove legacy Kotlin/JS target in favor of wasmJs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -338,7 +338,6 @@ tasks.register("ciCompile") {
     group = "CI"
     description = "Compiles all CI targets without packaging outputs"
     dependsOn(ChartsModules.ciKmpCompile.map { "$it:compileKotlinJvm" })
-    dependsOn((ChartsModules.library + ChartsModules.DEMO_SHARED).map { "$it:compileKotlinJs" })
     dependsOn(ChartsModules.ciKmpCompile.map { "$it:compileKotlinWasmJs" })
     dependsOn(ChartsModules.ciAndroidCompile.map { "$it:compileAndroidMain" })
     dependsOn(":smoke-line:compileKotlinJvm")

--- a/charts-bar/build.gradle.kts
+++ b/charts-bar/build.gradle.kts
@@ -44,10 +44,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    js {
-        browser()
-    }
-
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()

--- a/charts-core/build.gradle.kts
+++ b/charts-core/build.gradle.kts
@@ -40,10 +40,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    js {
-        browser()
-    }
-
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()

--- a/charts-demo-shared/build.gradle.kts
+++ b/charts-demo-shared/build.gradle.kts
@@ -42,10 +42,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    js {
-        browser()
-    }
-
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()

--- a/charts-histogram/build.gradle.kts
+++ b/charts-histogram/build.gradle.kts
@@ -44,10 +44,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    js {
-        browser()
-    }
-
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()

--- a/charts-line/build.gradle.kts
+++ b/charts-line/build.gradle.kts
@@ -44,10 +44,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    js {
-        browser()
-    }
-
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()

--- a/charts-pie/build.gradle.kts
+++ b/charts-pie/build.gradle.kts
@@ -44,10 +44,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    js {
-        browser()
-    }
-
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()

--- a/charts-radar/build.gradle.kts
+++ b/charts-radar/build.gradle.kts
@@ -44,10 +44,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    js {
-        browser()
-    }
-
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()

--- a/charts-stacked-area/build.gradle.kts
+++ b/charts-stacked-area/build.gradle.kts
@@ -44,10 +44,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    js {
-        browser()
-    }
-
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()

--- a/charts-stacked-bar/build.gradle.kts
+++ b/charts-stacked-bar/build.gradle.kts
@@ -44,10 +44,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    js {
-        browser()
-    }
-
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()

--- a/charts/build.gradle.kts
+++ b/charts/build.gradle.kts
@@ -45,10 +45,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    js {
-        browser()
-    }
-
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()

--- a/release-notes/2.5.0/changes/511-remove-js-target.md
+++ b/release-notes/2.5.0/changes/511-remove-js-target.md
@@ -1,0 +1,6 @@
+# PR Changeset
+
+- type: `chore`
+- module: `charts`
+- pr: `https://github.com/HDCharts/charts/pull/511`
+- release_note: `The legacy Kotlin/JS (js) target has been removed. Web support is now exclusively via Kotlin/Wasm (wasmJs).`

--- a/release-notes/2.5.0/migrations/511-remove-js-target.md
+++ b/release-notes/2.5.0/migrations/511-remove-js-target.md
@@ -1,0 +1,10 @@
+# Legacy Kotlin/JS target removed
+
+## What changed
+
+The `js` (Kotlin/JS) target was removed from all published modules. Web support is now exclusively via Kotlin/Wasm (`wasmJs`), which is already used by the web demo and playground.
+
+## What you should do
+
+- If you consumed the library from Kotlin/JS, migrate your web target to Kotlin/Wasm (`wasmJs`).
+- Consumers on JVM, Android, iOS, and wasmJs are unaffected.


### PR DESCRIPTION
## Summary

Removes the legacy Kotlin/JS (`js`) target from all published modules and `charts-demo-shared`. Web support is now exclusively via Kotlin/Wasm (`wasmJs`).

## Motivation

- The web demo and playground already build with `wasmJs`.
- CI tests run `wasmJsTest`; there is no `jsTest`.
- The `js` target was only compiled by `ciCompile` and added publish/sign/upload overhead (\~18 signed artifacts per snapshot) with no consumers.

## Changes

- Removed `js { browser() }` from `charts`, `charts-core`, `charts-line`, `charts-pie`, `charts-bar`, `charts-histogram`, `charts-stacked-bar`, `charts-stacked-area`, `charts-radar`, and `charts-demo-shared`.
- Removed the `compileKotlinJs` dependency from the root `ciCompile` task.

## Verification

- `chartsTestWasm` passes.
- `publishChartsModulesToMavenLocal --dry-run` contains no `js`-target tasks.
- The `webMain` source set (shared JS-family intermediate feeding `wasmJsMain`) still compiles into wasmJs.

> **Breaking:** JS-target consumers can no longer resolve the published library. See the migration fragment in release notes.