### PR TITLE
Extend CI skip paths for non-charts changes

### DIFF
--- a/scripts/ci-has-code-changes.sh
+++ b/scripts/ci-has-code-changes.sh
@@ -8,7 +8,7 @@ is_code_change() {
   while IFS= read -r changed_file; do
     [[ -n "$changed_file" ]] || continue
     case "$changed_file" in
-      docs/*|release-notes/*|gif-baselines/*|.editorconfig|*.md|LICENSE|LICENSE.*) ;;
+      docs/*|release-notes/*|gif-baselines/*|scripts/*|.editorconfig|*.md|LICENSE|LICENSE.*) ;;
       *)
         echo "true"
         return
@@ -87,8 +87,13 @@ run_self_test() {
     failures=$((failures + 1))
   fi
 
+  result="$(is_code_change $'README.md\nscripts/build-release-body.sh')"
+  if ! assert_equal "false" "$result" "ci/release script change"; then
+    failures=$((failures + 1))
+  fi
+
   result="$(is_code_change "scripts/ci-has-code-changes.sh")"
-  if ! assert_equal "true" "$result" "ci script change is a code change"; then
+  if ! assert_equal "false" "$result" "skip script change"; then
     failures=$((failures + 1))
   fi
 

--- a/scripts/ci-has-code-changes.sh
+++ b/scripts/ci-has-code-changes.sh
@@ -8,7 +8,7 @@ is_code_change() {
   while IFS= read -r changed_file; do
     [[ -n "$changed_file" ]] || continue
     case "$changed_file" in
-      docs/*|release-notes/*|*.md|LICENSE|LICENSE.*) ;;
+      docs/*|release-notes/*|gif-baselines/*|.editorconfig|*.md|LICENSE|LICENSE.*) ;;
       *)
         echo "true"
         return
@@ -79,6 +79,21 @@ run_self_test() {
 
   result="$(is_code_change "charts2/src/Main.kt")"
   if ! assert_equal "true" "$result" "new source directory"; then
+    failures=$((failures + 1))
+  fi
+
+  result="$(is_code_change $'README.md\ngif-baselines/bar.png')"
+  if ! assert_equal "false" "$result" "gif baseline change"; then
+    failures=$((failures + 1))
+  fi
+
+  result="$(is_code_change "scripts/ci-has-code-changes.sh")"
+  if ! assert_equal "true" "$result" "ci script change is a code change"; then
+    failures=$((failures + 1))
+  fi
+
+  result="$(is_code_change ".editorconfig")"
+  if ! assert_equal "false" "$result" "editor config change"; then
     failures=$((failures + 1))
   fi
 


### PR DESCRIPTION
## Why

Changes to GIF baselines, CI/release scripts, and editor config cannot affect chart
compilation or test results, yet they currently trigger the full multi-platform test
matrix on every PR, wasting CI time.

## Summary

Extend `scripts/ci-has-code-changes.sh` so pull requests that only touch
`gif-baselines/*`, `scripts/*`, or `.editorconfig` are treated as non-code changes and
skip the expensive JVM/Android/Wasm/iOS test suites, while still running the `prepare`
self-test that guards the skip logic.

## Changes

- Add `gif-baselines/*`, `scripts/*`, and `.editorconfig` to the skip patterns.
- Add self-test cases covering each new skip path.

## Release/Changeset

- Not required

## Notes/Risk

- None. Skip paths are non-source artifacts; the gating logic remains guarded by the
  existing self-test run in `pull-request.yml`.