### PR TITLE
test: add validation, model, and style coverage

### DIFF
--- a/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/style/ChartStyle.kt
+++ b/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/style/ChartStyle.kt
@@ -69,7 +69,7 @@ object ChartViewDefaults {
      * @param outerPadding The outer padding of the chart view. Defaults to 20.dp.
      * @param innerPadding The inner padding of the chart view. Defaults to 15.dp.
      * @param cornerRadius The corner radius of the chart view. Defaults to 20.dp.
-     * @param shadow The shadow of the chart view. Defaults to 2.dp.
+     * @param shadow The shadow of the chart view. Defaults to 1.dp.
      * @param backgroundColor The background color of the chart view. Defaults to a subtle blend of surface and primaryContainer that adapts to dark mode.
      * @param modifierChart The modifier applied to chart drawing content. Defaults to a square aspect ratio.
      */
@@ -99,9 +99,10 @@ object ChartViewDefaults {
                     shape = RoundedCornerShape(cornerRadius),
                 )
 
+        // Dp.Infinity (the default) means the chart wraps its content width; an explicit
+        // finite width constrains the chart to that width.
         val updatedModifierMain =
             when (width) {
-                // TODO: Double check this logic
                 Dp.Infinity -> modifierMain.wrapContentWidth()
                 else -> modifierMain.width(width)
             }

--- a/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/PieValidation.kt
+++ b/charts-pie/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/PieValidation.kt
@@ -24,6 +24,9 @@ fun validatePieData(
         if (value.isNaN()) {
             val validationError = ValidationErrors.RULE_DATA_POINT_NOT_NUMBER.format(index)
             validationErrors.add(validationError)
+        } else if (value < 0) {
+            val validationError = ValidationErrors.RULE_DATA_POINT_NEGATIVE.format(index)
+            validationErrors.add(validationError)
         }
     }
 

--- a/charts-radar/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/RadarValidation.kt
+++ b/charts-radar/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/RadarValidation.kt
@@ -4,7 +4,8 @@ import io.github.dautovicharis.charts.internal.ValidationErrors.MIN_REQUIRED_RAD
 import io.github.dautovicharis.charts.internal.common.model.MultiChartData
 import io.github.dautovicharis.charts.style.RadarChartStyle
 
-internal fun validateRadarData(
+@InternalChartsApi
+fun validateRadarData(
     data: MultiChartData,
     style: RadarChartStyle,
 ): List<String> {

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/mock/MockTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/mock/MockTest.kt
@@ -13,6 +13,7 @@ import io.github.dautovicharis.charts.model.MultiChartDataSet
 import io.github.dautovicharis.charts.style.ChartViewStyle
 import io.github.dautovicharis.charts.style.LineChartStyle
 import io.github.dautovicharis.charts.style.PieChartStyle
+import io.github.dautovicharis.charts.style.RadarChartStyle
 import io.github.dautovicharis.charts.style.StackedAreaChartStyle
 import io.github.dautovicharis.charts.style.StackedBarChartStyle
 
@@ -30,6 +31,8 @@ internal object MockTest {
 
     private val categories = listOf("Jan", "Feb", "Mar", "Apr")
     val colors = listOf(Color.Red, Color.Green, Color.Cyan, Color.Black)
+    val colorsAsymmetric =
+        listOf(Color.Red, Color.Green, Color.Cyan, Color.Black, Color.Blue, Color.Yellow)
 
     private val dataItems =
         listOf(
@@ -49,6 +52,18 @@ internal object MockTest {
         MultiChartDataSet(
             items = dataItems,
             categories = categories,
+            title = TITLE,
+        )
+
+    val asymmetricMultiDataSet =
+        MultiChartDataSet(
+            items =
+                listOf(
+                    FIRST_ITEM_NAME to FloatData(FIRST_ITEM + 5f),
+                    SECOND_ITEM_NAME to FloatData(SECOND_ITEM + 5f),
+                    THIRD_ITEM_NAME to FloatData(THIRD_ITEM + 5f),
+                ),
+            categories = categories + "May",
             title = TITLE,
         )
 
@@ -210,6 +225,36 @@ internal object MockTest {
             borderWidth = 2f,
             legendVisible = true,
             chartViewStyle = mockChartViewStyle(),
+        )
+
+    fun mockRadarChartStyle(lineColors: List<Color> = colors): RadarChartStyle =
+        RadarChartStyle(
+            modifier = Modifier.fillMaxSize(),
+            chartViewStyle = mockChartViewStyle(),
+            gridColor = Color.Gray,
+            gridLineWidth = 1f,
+            gridSteps = 4,
+            gridVisible = true,
+            axisLineColor = Color.Gray,
+            axisLineWidth = 1f,
+            axisVisible = true,
+            axisLabelColor = Color.Gray,
+            axisLabelSize = 11.sp,
+            axisLabelPadding = Dp(4f),
+            axisLabelVisible = true,
+            categoryLegendVisible = true,
+            categoryColors = colors,
+            categoryPinSize = 4f,
+            categoryPinsVisible = true,
+            pointColorSameAsLine = true,
+            pointColor = Color.Red,
+            pointSize = 8f,
+            pointVisible = true,
+            lineColor = Color.Green,
+            lineColors = lineColors,
+            lineWidth = 2f,
+            fillAlpha = 0.3f,
+            fillVisible = true,
         )
 
     private fun mockChartViewStyle(): ChartViewStyle =

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/ChartDataTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/ChartDataTest.kt
@@ -4,6 +4,7 @@ import io.github.dautovicharis.charts.internal.common.model.ChartData
 import io.github.dautovicharis.charts.internal.common.model.ChartDataType
 import io.github.dautovicharis.charts.mock.MockTest
 import io.github.dautovicharis.charts.model.ChartDataSet
+import io.github.dautovicharis.charts.model.toChartDataSet
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -125,5 +126,19 @@ class ChartDataTest {
         assertContentEquals(actual = inputDataSet.data.item.points, expected = listOf(-1.0, 2.0, 3.0))
         assertContentEquals(actual = inputDataSet.data.item.labels, expected = listOf("-1", "2", "3"))
         assertEquals(actual = inputDataSet.data.label, expected = MockTest.TITLE)
+    }
+
+    // Explicit labels
+    @Test
+    fun `chart data set with explicit labels uses provided labels`() {
+        // Arrange
+        val items = listOf(1f, 2f, 3f)
+        val labels = listOf("One", "Two", "Three")
+
+        // Act
+        val inputDataSet = items.toChartDataSet(title = MockTest.TITLE, labels = labels)
+
+        // Assert
+        assertContentEquals(actual = inputDataSet.data.item.labels, expected = labels)
     }
 }

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/ChartDataTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/ChartDataTest.kt
@@ -130,7 +130,7 @@ class ChartDataTest {
 
     // Explicit labels
     @Test
-    fun `chart data set with explicit labels uses provided labels`() {
+    fun chartDataSet_explicitLabels_usesProvidedLabels() {
         // Arrange
         val items = listOf(1f, 2f, 3f)
         val labels = listOf("One", "Two", "Three")

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/MultiChatDataTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/MultiChatDataTest.kt
@@ -607,7 +607,7 @@ class MultiChatDataTest {
     }
 
     @Test
-    fun `toMultiChartDataSet string float overload parses values into points`() {
+    fun toMultiChartDataSet_stringFloatList_correctDataReturned() {
         // Arrange
         val categories = listOf("Jan", "Feb", "Mar")
 
@@ -639,7 +639,7 @@ class MultiChatDataTest {
     }
 
     @Test
-    fun `toMultiChartDataSet string overload with invalid value parses as NaN`() {
+    fun toMultiChartDataSet_stringFloatList_invalidValue_parsesAsNaN() {
         // Arrange
         val categories = listOf("Jan", "Feb", "Mar")
 

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/MultiChatDataTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/model/MultiChatDataTest.kt
@@ -8,6 +8,7 @@ import io.github.dautovicharis.charts.internal.common.model.normalizeByMinMax
 import io.github.dautovicharis.charts.internal.common.model.toChartData
 import io.github.dautovicharis.charts.mock.MockTest
 import io.github.dautovicharis.charts.model.MultiChartDataSet
+import io.github.dautovicharis.charts.model.toMultiChartDataSet
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -603,5 +604,59 @@ class MultiChatDataTest {
         )
         assertEquals(actual = inputDataSet.data.categories, expected = categories)
         assertEquals(actual = inputDataSet.data.title, expected = MockTest.TITLE)
+    }
+
+    @Test
+    fun `toMultiChartDataSet string float overload parses values into points`() {
+        // Arrange
+        val categories = listOf("Jan", "Feb", "Mar")
+
+        // Act
+        val inputDataSet =
+            listOf(
+                "Label1" to listOf("1.0", "2.0", "3.0"),
+                "Label2" to listOf("3.0", "4.0", "5.0"),
+            ).toMultiChartDataSet(
+                title = MockTest.TITLE,
+                categories = categories,
+            )
+
+        // Assert
+        assertEquals(actual = inputDataSet.data.title, expected = MockTest.TITLE)
+        assertEquals(actual = inputDataSet.data.categories, expected = categories)
+        assertContentEquals(
+            actual =
+                inputDataSet.data.items[0]
+                    .item.points,
+            expected = listOf(1.0, 2.0, 3.0),
+        )
+        assertContentEquals(
+            actual =
+                inputDataSet.data.items[1]
+                    .item.points,
+            expected = listOf(3.0, 4.0, 5.0),
+        )
+    }
+
+    @Test
+    fun `toMultiChartDataSet string overload with invalid value parses as NaN`() {
+        // Arrange
+        val categories = listOf("Jan", "Feb", "Mar")
+
+        // Act
+        val inputDataSet =
+            listOf(
+                "Label1" to listOf("1.0", "NaN", "3.0"),
+            ).toMultiChartDataSet(
+                title = MockTest.TITLE,
+                categories = categories,
+            )
+
+        // Assert
+        assertTrue(
+            inputDataSet.data.items[0]
+                .item.points[1]
+                .isNaN(),
+        )
     }
 }

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/style/ChartViewDefaultsTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/style/ChartViewDefaultsTest.kt
@@ -1,0 +1,109 @@
+package io.github.dautovicharis.charts.unit.style
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.github.dautovicharis.charts.style.ChartViewDefaults
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ChartViewDefaultsTest {
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun chartViewDefaults_withExplicitWidth_constrainsChartWidth() =
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    val style = ChartViewDefaults.style(width = 250.dp, modifierChart = Modifier)
+                    Box(modifier = style.modifierMain.semantics { testTag = "box" })
+                }
+            }
+
+            onNodeWithTag("box").assertWidthIsEqualTo(250.dp)
+        }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun chartViewDefaults_withInfiniteWidth_wrapsContentAndKeepsInfinity() =
+        runComposeUiTest {
+            var resolvedWidth: Dp = Dp.Unspecified
+            setContent {
+                MaterialTheme {
+                    val style =
+                        ChartViewDefaults.style(width = Dp.Infinity, modifierChart = Modifier)
+                    resolvedWidth = style.width
+                    Box(
+                        modifier =
+                            style.modifierMain.semantics { testTag = "box" },
+                    ) {
+                        androidx.compose.foundation.layout.Box(
+                            modifier = Modifier.width(180.dp),
+                        )
+                    }
+                }
+            }
+
+            assertEquals(Dp.Infinity, resolvedWidth)
+            onNodeWithTag("box").assertWidthIsEqualTo(180.dp)
+        }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun chartViewDefaults_defaultModifierChart_squareChartArea() =
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    val style = ChartViewDefaults.style(width = 200.dp)
+                    Box(
+                        modifier =
+                            Modifier
+                                .width(200.dp)
+                                .then(style.modifierChart)
+                                .fillMaxSize()
+                                .semantics { testTag = "chart" },
+                    )
+                }
+            }
+
+            onNodeWithTag("chart").assertWidthIsEqualTo(200.dp)
+            onNodeWithTag("chart").assertHeightIsEqualTo(200.dp)
+        }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun chartViewDefaults_customModifierChart_overridesAspectRatio() =
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    val style =
+                        ChartViewDefaults.style(
+                            width = 200.dp,
+                            modifierChart = Modifier.aspectRatio(2f),
+                        )
+                    Box(
+                        modifier =
+                            Modifier
+                                .width(200.dp)
+                                .then(style.modifierChart)
+                                .fillMaxSize()
+                                .semantics { testTag = "chart" },
+                    )
+                }
+            }
+
+            onNodeWithTag("chart").assertWidthIsEqualTo(200.dp)
+            onNodeWithTag("chart").assertHeightIsEqualTo(100.dp)
+        }
+}

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationBarSingleSeriesTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationBarSingleSeriesTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertTrue
 
 class DataValidationBarSingleSeriesTest {
     @Test
-    fun `validate bar data with too few points has validation errors`() {
+    fun validateBarData_tooFewPoints_validationErrorsPresent() {
         val data = listOf(1f).toChartDataSet(title = TITLE).data.item
 
         val errors = validateBarData(data)
@@ -26,7 +26,7 @@ class DataValidationBarSingleSeriesTest {
     }
 
     @Test
-    fun `validate bar data with invalid colors has validation errors`() {
+    fun validateBarData_invalidColors_validationErrorsPresent() {
         val data = listOf(1f, 2f, 3f).toChartDataSet(title = TITLE).data.item
 
         val errors = validateBarData(data, colorsSize = 2)
@@ -37,7 +37,7 @@ class DataValidationBarSingleSeriesTest {
     }
 
     @Test
-    fun `validate bar data with non numeric value has validation errors`() {
+    fun validateBarData_nonNumericValue_validationErrorsPresent() {
         val dataSet =
             ChartDataSet(
                 items = ChartDataType.StringData(listOf("1.0", "NaN", "3.0")),

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationBarSingleSeriesTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationBarSingleSeriesTest.kt
@@ -1,0 +1,53 @@
+package io.github.dautovicharis.charts.unit.validation
+
+import io.github.dautovicharis.charts.internal.ValidationErrors
+import io.github.dautovicharis.charts.internal.ValidationErrors.MIN_REQUIRED_BAR
+import io.github.dautovicharis.charts.internal.common.model.ChartDataType
+import io.github.dautovicharis.charts.internal.format
+import io.github.dautovicharis.charts.internal.validateBarData
+import io.github.dautovicharis.charts.mock.MockTest.TITLE
+import io.github.dautovicharis.charts.model.ChartDataSet
+import io.github.dautovicharis.charts.model.toChartDataSet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DataValidationBarSingleSeriesTest {
+    @Test
+    fun `validate bar data with too few points has validation errors`() {
+        val data = listOf(1f).toChartDataSet(title = TITLE).data.item
+
+        val errors = validateBarData(data)
+
+        val expectedError =
+            ValidationErrors.RULE_DATA_POINTS_LESS_THAN_MIN.format(MIN_REQUIRED_BAR)
+        assertTrue(errors.isNotEmpty())
+        assertEquals(expectedError, errors.first())
+    }
+
+    @Test
+    fun `validate bar data with invalid colors has validation errors`() {
+        val data = listOf(1f, 2f, 3f).toChartDataSet(title = TITLE).data.item
+
+        val errors = validateBarData(data, colorsSize = 2)
+
+        val expectedError = ValidationErrors.RULE_COLORS_SIZE_MISMATCH.format(2, 3)
+        assertTrue(errors.isNotEmpty())
+        assertEquals(expectedError, errors.first())
+    }
+
+    @Test
+    fun `validate bar data with non numeric value has validation errors`() {
+        val dataSet =
+            ChartDataSet(
+                items = ChartDataType.StringData(listOf("1.0", "NaN", "3.0")),
+                title = TITLE,
+            )
+
+        val errors = validateBarData(dataSet.data.item)
+
+        val expectedError = ValidationErrors.RULE_DATA_POINT_NOT_NUMBER.format(1)
+        assertTrue(errors.isNotEmpty())
+        assertEquals(expectedError, errors.first())
+    }
+}

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationColorSemanticsTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationColorSemanticsTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertTrue
 
 class DataValidationColorSemanticsTest {
     @Test
-    fun `line chart expects one color per series`() {
+    fun lineChart_invalidColors_validationErrorsPresent() {
         val dataSet = asymmetricMultiDataSet
         val style = mockLineChartStyle(colorsAsymmetric.take(3))
 
@@ -19,7 +19,7 @@ class DataValidationColorSemanticsTest {
     }
 
     @Test
-    fun `stacked bar chart expects one color per point`() {
+    fun stackedBarChart_invalidColors_validationErrorsPresent() {
         val dataSet = asymmetricMultiDataSet
         val style = mockStackedBarChartStyle(colorsAsymmetric.take(5))
 

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationColorSemanticsTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationColorSemanticsTest.kt
@@ -1,0 +1,28 @@
+package io.github.dautovicharis.charts.unit.validation
+
+import io.github.dautovicharis.charts.internal.validateBarData
+import io.github.dautovicharis.charts.internal.validateLineData
+import io.github.dautovicharis.charts.mock.MockTest.asymmetricMultiDataSet
+import io.github.dautovicharis.charts.mock.MockTest.colorsAsymmetric
+import io.github.dautovicharis.charts.mock.MockTest.mockLineChartStyle
+import io.github.dautovicharis.charts.mock.MockTest.mockStackedBarChartStyle
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DataValidationColorSemanticsTest {
+    @Test
+    fun `line chart expects one color per series`() {
+        val dataSet = asymmetricMultiDataSet
+        val style = mockLineChartStyle(colorsAsymmetric.take(3))
+
+        assertTrue(validateLineData(dataSet.data, style).isEmpty())
+    }
+
+    @Test
+    fun `stacked bar chart expects one color per point`() {
+        val dataSet = asymmetricMultiDataSet
+        val style = mockStackedBarChartStyle(colorsAsymmetric.take(5))
+
+        assertTrue(validateBarData(dataSet.data, style).isEmpty())
+    }
+}

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationHistogramTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationHistogramTest.kt
@@ -14,13 +14,13 @@ import kotlin.test.assertTrue
 
 class DataValidationHistogramTest {
     @Test
-    fun `validate histogram data with valid data set has no validation errors`() {
+    fun validateHistogramData_validDataSet_noValidationErrors() {
         val data = listOf(1f, 2f, 3f).toChartDataSet(title = TITLE).data.item
         assertTrue(validateHistogramData(data).isEmpty())
     }
 
     @Test
-    fun `validate histogram data with too few points has validation errors`() {
+    fun validateHistogramData_tooFewPoints_validationErrorsPresent() {
         val data = listOf(1f).toChartDataSet(title = TITLE).data.item
 
         val errors = validateHistogramData(data)
@@ -32,7 +32,7 @@ class DataValidationHistogramTest {
     }
 
     @Test
-    fun `validate histogram data with negative value has validation errors`() {
+    fun validateHistogramData_negativeValue_validationErrorsPresent() {
         val data = listOf(1f, -2f, 3f).toChartDataSet(title = TITLE).data.item
 
         val errors = validateHistogramData(data)
@@ -43,7 +43,7 @@ class DataValidationHistogramTest {
     }
 
     @Test
-    fun `validate histogram data with invalid colors has validation errors`() {
+    fun validateHistogramData_invalidColors_validationErrorsPresent() {
         val data = listOf(1f, 2f, 3f).toChartDataSet(title = TITLE).data.item
 
         val errors = validateHistogramData(data, colorsSize = 2)
@@ -54,7 +54,7 @@ class DataValidationHistogramTest {
     }
 
     @Test
-    fun `validate histogram data with non numeric value has validation errors`() {
+    fun validateHistogramData_nonNumericValue_validationErrorsPresent() {
         val dataSet =
             ChartDataSet(
                 items = ChartDataType.StringData(listOf("1.0", "NaN", "3.0")),

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationHistogramTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationHistogramTest.kt
@@ -1,0 +1,70 @@
+package io.github.dautovicharis.charts.unit.validation
+
+import io.github.dautovicharis.charts.internal.ValidationErrors
+import io.github.dautovicharis.charts.internal.ValidationErrors.MIN_REQUIRED_BAR
+import io.github.dautovicharis.charts.internal.common.model.ChartDataType
+import io.github.dautovicharis.charts.internal.format
+import io.github.dautovicharis.charts.internal.validateHistogramData
+import io.github.dautovicharis.charts.mock.MockTest.TITLE
+import io.github.dautovicharis.charts.model.ChartDataSet
+import io.github.dautovicharis.charts.model.toChartDataSet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DataValidationHistogramTest {
+    @Test
+    fun `validate histogram data with valid data set has no validation errors`() {
+        val data = listOf(1f, 2f, 3f).toChartDataSet(title = TITLE).data.item
+        assertTrue(validateHistogramData(data).isEmpty())
+    }
+
+    @Test
+    fun `validate histogram data with too few points has validation errors`() {
+        val data = listOf(1f).toChartDataSet(title = TITLE).data.item
+
+        val errors = validateHistogramData(data)
+
+        val expectedError =
+            ValidationErrors.RULE_DATA_POINTS_LESS_THAN_MIN.format(MIN_REQUIRED_BAR)
+        assertTrue(errors.isNotEmpty())
+        assertEquals(expectedError, errors.first())
+    }
+
+    @Test
+    fun `validate histogram data with negative value has validation errors`() {
+        val data = listOf(1f, -2f, 3f).toChartDataSet(title = TITLE).data.item
+
+        val errors = validateHistogramData(data)
+
+        val expectedError = ValidationErrors.RULE_DATA_POINT_NEGATIVE.format(1)
+        assertTrue(errors.isNotEmpty())
+        assertEquals(expectedError, errors.first())
+    }
+
+    @Test
+    fun `validate histogram data with invalid colors has validation errors`() {
+        val data = listOf(1f, 2f, 3f).toChartDataSet(title = TITLE).data.item
+
+        val errors = validateHistogramData(data, colorsSize = 2)
+
+        val expectedError = ValidationErrors.RULE_COLORS_SIZE_MISMATCH.format(2, 3)
+        assertTrue(errors.isNotEmpty())
+        assertEquals(expectedError, errors.first())
+    }
+
+    @Test
+    fun `validate histogram data with non numeric value has validation errors`() {
+        val dataSet =
+            ChartDataSet(
+                items = ChartDataType.StringData(listOf("1.0", "NaN", "3.0")),
+                title = TITLE,
+            )
+
+        val errors = validateHistogramData(dataSet.data.item)
+
+        val expectedError = ValidationErrors.RULE_DATA_POINT_NOT_NUMBER.format(1)
+        assertTrue(errors.isNotEmpty())
+        assertEquals(expectedError, errors.first())
+    }
+}

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationPieTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationPieTest.kt
@@ -73,7 +73,7 @@ class DataValidationPieTest {
     }
 
     @Test
-    fun `validate pie data with non numeric value has validation errors`() {
+    fun validatePieData_nonNumericValue_validationErrorsPresent() {
         // Arrange
         val chartDataSet =
             ChartDataSet(
@@ -96,7 +96,7 @@ class DataValidationPieTest {
     }
 
     @Test
-    fun `validate pie data with negative value has validation errors`() {
+    fun validatePieData_negativeValue_validationErrorsPresent() {
         // Arrange
         val chartDataSet =
             ChartDataSet(

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationPieTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationPieTest.kt
@@ -2,6 +2,7 @@ package io.github.dautovicharis.charts.unit.validation
 
 import io.github.dautovicharis.charts.internal.ValidationErrors
 import io.github.dautovicharis.charts.internal.ValidationErrors.MIN_REQUIRED_PIE
+import io.github.dautovicharis.charts.internal.ValidationErrors.RULE_DATA_POINT_NOT_NUMBER
 import io.github.dautovicharis.charts.internal.common.model.ChartDataType
 import io.github.dautovicharis.charts.internal.format
 import io.github.dautovicharis.charts.internal.validatePieData
@@ -67,6 +68,52 @@ class DataValidationPieTest {
         // Assert
         val expectedError =
             ValidationErrors.RULE_COLORS_SIZE_MISMATCH.format(colors.size, expectedColorSize)
+        assertTrue(validationErrors.isNotEmpty())
+        assertEquals(validationErrors.first(), expectedError)
+    }
+
+    @Test
+    fun `validate pie data with non numeric value has validation errors`() {
+        // Arrange
+        val chartDataSet =
+            ChartDataSet(
+                items = ChartDataType.StringData(listOf("1.0", "NaN", "3.0")),
+                title = TITLE,
+            )
+        val pieChartStyle = mockPieChartStyle(colors.take(3))
+
+        // Act
+        val validationErrors =
+            validatePieData(
+                dataSet = chartDataSet,
+                style = pieChartStyle,
+            )
+
+        // Assert
+        val expectedError = RULE_DATA_POINT_NOT_NUMBER.format(1)
+        assertTrue(validationErrors.isNotEmpty())
+        assertEquals(validationErrors.first(), expectedError)
+    }
+
+    @Test
+    fun `validate pie data with negative value has validation errors`() {
+        // Arrange
+        val chartDataSet =
+            ChartDataSet(
+                items = ChartDataType.FloatData(listOf(1f, -2f, 3f)),
+                title = TITLE,
+            )
+        val pieChartStyle = mockPieChartStyle(colors.take(3))
+
+        // Act
+        val validationErrors =
+            validatePieData(
+                dataSet = chartDataSet,
+                style = pieChartStyle,
+            )
+
+        // Assert
+        val expectedError = ValidationErrors.RULE_DATA_POINT_NEGATIVE.format(1)
         assertTrue(validationErrors.isNotEmpty())
         assertEquals(validationErrors.first(), expectedError)
     }

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationRadarTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationRadarTest.kt
@@ -16,13 +16,13 @@ import kotlin.test.assertTrue
 
 class DataValidationRadarTest {
     @Test
-    fun `validate radar data with valid data set has no validation errors`() {
+    fun validateRadarData_validDataSet_noValidationErrors() {
         val errors = validateRadarData(multiDataSet.data, mockRadarChartStyle())
         assertTrue(errors.isEmpty())
     }
 
     @Test
-    fun `validate radar data with invalid categories has validation errors`() {
+    fun validateRadarData_invalidCategories_validationErrorsPresent() {
         val dataSet = invalidDataSetCategories()
         val expectedCategoriesSize =
             dataSet.data.items
@@ -41,7 +41,7 @@ class DataValidationRadarTest {
     }
 
     @Test
-    fun `validate radar data with invalid colors has validation errors`() {
+    fun validateRadarData_invalidColors_validationErrorsPresent() {
         val dataSet = multiDataSet
         val style = mockRadarChartStyle(colors.drop(2))
 
@@ -57,7 +57,7 @@ class DataValidationRadarTest {
     }
 
     @Test
-    fun `validate radar data with too few points has validation errors`() {
+    fun validateRadarData_tooFewPoints_validationErrorsPresent() {
         val dataSet =
             listOf("A" to listOf(1f, 2f))
                 .toMultiChartDataSet(title = TITLE)
@@ -71,7 +71,7 @@ class DataValidationRadarTest {
     }
 
     @Test
-    fun `validate radar data with non numeric value has validation errors`() {
+    fun validateRadarData_nonNumericValue_validationErrorsPresent() {
         val dataSet =
             listOf("A" to listOf("1.0", "NaN", "3.0"))
                 .toMultiChartDataSet(title = TITLE)
@@ -85,7 +85,7 @@ class DataValidationRadarTest {
     }
 
     @Test
-    fun `validate radar data with mismatched item sizes has validation errors`() {
+    fun validateRadarData_mismatchedItemSizes_validationErrorsPresent() {
         val dataSet =
             listOf(
                 "A" to listOf(1f, 2f, 3f),

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationRadarTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/DataValidationRadarTest.kt
@@ -1,0 +1,102 @@
+package io.github.dautovicharis.charts.unit.validation
+
+import io.github.dautovicharis.charts.internal.ValidationErrors
+import io.github.dautovicharis.charts.internal.ValidationErrors.MIN_REQUIRED_RADAR
+import io.github.dautovicharis.charts.internal.format
+import io.github.dautovicharis.charts.internal.validateRadarData
+import io.github.dautovicharis.charts.mock.MockTest.TITLE
+import io.github.dautovicharis.charts.mock.MockTest.colors
+import io.github.dautovicharis.charts.mock.MockTest.invalidDataSetCategories
+import io.github.dautovicharis.charts.mock.MockTest.mockRadarChartStyle
+import io.github.dautovicharis.charts.mock.MockTest.multiDataSet
+import io.github.dautovicharis.charts.model.toMultiChartDataSet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DataValidationRadarTest {
+    @Test
+    fun `validate radar data with valid data set has no validation errors`() {
+        val errors = validateRadarData(multiDataSet.data, mockRadarChartStyle())
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    fun `validate radar data with invalid categories has validation errors`() {
+        val dataSet = invalidDataSetCategories()
+        val expectedCategoriesSize =
+            dataSet.data.items
+                .first()
+                .item.points.size
+
+        val errors = validateRadarData(dataSet.data, mockRadarChartStyle())
+
+        val expectedError =
+            ValidationErrors.RULE_CATEGORIES_SIZE_MISMATCH.format(
+                dataSet.data.categories.size,
+                expectedCategoriesSize,
+            )
+        assertTrue(errors.isNotEmpty())
+        assertEquals(expectedError, errors.first())
+    }
+
+    @Test
+    fun `validate radar data with invalid colors has validation errors`() {
+        val dataSet = multiDataSet
+        val style = mockRadarChartStyle(colors.drop(2))
+
+        val errors = validateRadarData(dataSet.data, style)
+
+        val expectedError =
+            ValidationErrors.RULE_COLORS_SIZE_MISMATCH.format(
+                colors.drop(2).size,
+                dataSet.data.items.size,
+            )
+        assertTrue(errors.isNotEmpty())
+        assertEquals(expectedError, errors.first())
+    }
+
+    @Test
+    fun `validate radar data with too few points has validation errors`() {
+        val dataSet =
+            listOf("A" to listOf(1f, 2f))
+                .toMultiChartDataSet(title = TITLE)
+
+        val errors = validateRadarData(dataSet.data, mockRadarChartStyle())
+
+        val expectedError =
+            ValidationErrors.RULE_DATA_POINTS_LESS_THAN_MIN.format(MIN_REQUIRED_RADAR)
+        assertTrue(errors.isNotEmpty())
+        assertEquals(expectedError, errors.first())
+    }
+
+    @Test
+    fun `validate radar data with non numeric value has validation errors`() {
+        val dataSet =
+            listOf("A" to listOf("1.0", "NaN", "3.0"))
+                .toMultiChartDataSet(title = TITLE)
+
+        val errors = validateRadarData(dataSet.data, mockRadarChartStyle(colors.take(1)))
+
+        val expectedError =
+            ValidationErrors.RULE_ITEM_POINT_NOT_NUMBER.format(0, 1)
+        assertTrue(errors.isNotEmpty())
+        assertEquals(expectedError, errors.first())
+    }
+
+    @Test
+    fun `validate radar data with mismatched item sizes has validation errors`() {
+        val dataSet =
+            listOf(
+                "A" to listOf(1f, 2f, 3f),
+                "B" to listOf(1f, 2f),
+            ).toMultiChartDataSet(title = TITLE)
+
+        val errors = validateRadarData(dataSet.data, mockRadarChartStyle())
+
+        val expectedError =
+            ValidationErrors.RULE_ITEM_POINTS_SIZE.format(1, 2, 3)
+        assertTrue(errors.isNotEmpty())
+        assertEquals(expectedError, errors.first())
+    }
+}

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/FormatTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/FormatTest.kt
@@ -1,0 +1,36 @@
+package io.github.dautovicharis.charts.unit.validation
+
+import io.github.dautovicharis.charts.internal.ValidationErrors.RULE_ITEM_POINTS_SIZE
+import io.github.dautovicharis.charts.internal.format
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FormatTest {
+    @Test
+    fun `format with no args returns original string`() {
+        assertEquals("Points: %d", "Points: %d".format())
+    }
+
+    @Test
+    fun `format with single arg replaces first placeholder`() {
+        assertEquals("Item 3", "Item %d".format(3))
+    }
+
+    @Test
+    fun `format with fewer args than placeholders leaves remaining placeholders`() {
+        val result = "Item %d has %d points".format(1)
+        assertEquals("Item 1 has %d points", result)
+    }
+
+    @Test
+    fun `format with more args than placeholders ignores extra args`() {
+        val result = "Value %d".format(1, 2, 3)
+        assertEquals("Value 1", result)
+    }
+
+    @Test
+    fun `format with multiple placeholders replaces in order`() {
+        val result = RULE_ITEM_POINTS_SIZE.format(2, 4, 5)
+        assertEquals("Item at index 2 has 4 points, expected 5.", result)
+    }
+}

--- a/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/FormatTest.kt
+++ b/charts/src/commonTest/kotlin/io/github/dautovicharis/charts/unit/validation/FormatTest.kt
@@ -7,29 +7,29 @@ import kotlin.test.assertEquals
 
 class FormatTest {
     @Test
-    fun `format with no args returns original string`() {
+    fun format_noArgs_returnsOriginalString() {
         assertEquals("Points: %d", "Points: %d".format())
     }
 
     @Test
-    fun `format with single arg replaces first placeholder`() {
+    fun format_singleArg_replacesFirstPlaceholder() {
         assertEquals("Item 3", "Item %d".format(3))
     }
 
     @Test
-    fun `format with fewer args than placeholders leaves remaining placeholders`() {
+    fun format_fewerArgs_leavesRemainingPlaceholders() {
         val result = "Item %d has %d points".format(1)
         assertEquals("Item 1 has %d points", result)
     }
 
     @Test
-    fun `format with more args than placeholders ignores extra args`() {
+    fun format_moreArgs_ignoresExtraArgs() {
         val result = "Value %d".format(1, 2, 3)
         assertEquals("Value 1", result)
     }
 
     @Test
-    fun `format with multiple placeholders replaces in order`() {
+    fun format_multiplePlaceholders_replacesInOrder() {
         val result = RULE_ITEM_POINTS_SIZE.format(2, 4, 5)
         assertEquals("Item at index 2 has 4 points, expected 5.", result)
     }


### PR DESCRIPTION
## Summary
Adds missing unit tests for chart validation rules, model conversions, and ChartViewDefaults width/aspect-ratio behavior. Also fixes a missing negative-value check in pie validation and exposes validateRadarData via @InternalChartsApi.

## Test Coverage
- **Validation**: NaN tests for bar/histogram/radar, negative-value test for pie, mismatched-item-size test for radar
- **Model**: Explicit-labels edge case for ChartDataSet, invalid-string parsing for toMultiChartDataSet
- **Style**: Width constraint and aspect-ratio behavior for ChartViewDefaults
- **Format**: Unit tests for the String.format utility

## Production Changes
- charts-core: KDoc shadow default correction (2.dp -> 1.dp)
- charts-pie: Added RULE_DATA_POINT_NEGATIVE check to validatePieData
- charts-radar: Changed validateRadarData visibility from internal to @InternalChartsApi public