### PR TITLE
chore: rebrand project as HDCharts

### DIFF
--- a/.github/actions/publish-github-prerelease/action.yml
+++ b/.github/actions/publish-github-prerelease/action.yml
@@ -49,7 +49,7 @@ runs:
           const sourceSha = process.env.SOURCE_SHA;
           const highlights = process.env.HIGHLIGHTS || '';
           const tag = 'snapshot';
-          const name = `Charts ${process.env.VERSION}`;
+          const name = `HDCharts ${process.env.VERSION}`;
 
           let refExists = false;
           try {

--- a/.github/actions/publish-github-release/action.yml
+++ b/.github/actions/publish-github-release/action.yml
@@ -70,7 +70,7 @@ runs:
             owner, repo,
             tag_name: version,
             target_commitish: process.env.SOURCE_SHA,
-            name: `Charts ${version}`,
+            name: `HDCharts ${version}`,
             body,
             draft: false,
             prerelease: false,

--- a/.github/actions/validate-docs-static-release/action.yml
+++ b/.github/actions/validate-docs-static-release/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: Release version expected in docs/static release assets.
   source-sha:
     required: true
-    description: Charts commit SHA expected in docs release metadata.
+    description: HDCharts commit SHA expected in docs release metadata.
   docs-static-bucket:
     required: true
     description: S3 bucket containing docs/static assets.

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
       source-sha:
-        description: Charts commit represented by the Android build.
+        description: HDCharts commit represented by the Android build.
         required: true
         type: string
       published-version:

--- a/.github/workflows/publish-static-assets.yml
+++ b/.github/workflows/publish-static-assets.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       source-sha:
-        description: Charts commit represented by this publication.
+        description: HDCharts commit represented by this publication.
         required: true
         type: string
       source-ref:

--- a/.github/workflows/validate-gifs.yml
+++ b/.github/workflows/validate-gifs.yml
@@ -1,4 +1,4 @@
-# Reusable workflow that validates the committed Charts GIF baselines.
+# Reusable workflow that validates the committed HDCharts GIF baselines.
 #
 # Generated GIFs and the comparison report are uploaded for manual review. This
 # workflow never modifies the pull request or repository contents.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ commonMain.dependencies {
     implementation("io.github.dautovicharis:charts-stacked-bar:<version>")
     implementation("io.github.dautovicharis:charts-stacked-area:<version>")
     implementation("io.github.dautovicharis:charts-radar:<version>")
-    // Optional: add charts-core directly only if you need shared base APIs
-    implementation("io.github.dautovicharis:charts-core:<version>")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <p align="center">
   <img
-    src="https://github.com/user-attachments/assets/4150f102-1b05-4fd7-ab01-63480d2e6d50"
+    src="./hdcharts-logo.svg"
     alt="HDCharts logo"
+    align="center"
     width="300"
   />
 </p>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img
-    src="https://github.com/dautovicharis/Charts/assets/7049715/4150f102-1b05-4fd7-ab01-63480d2e6d50"
-    alt="Charts logo"
+    src="https://github.com/user-attachments/assets/4150f102-1b05-4fd7-ab01-63480d2e6d50"
+    alt="HDCharts logo"
     width="300"
   />
 </p>
@@ -51,7 +51,7 @@ dependencyResolutionManagement {
 ```
 
 
-### All Charts
+### All chart types
 
 Use the umbrella artifact when you want all chart types with the simplest setup.
 
@@ -61,7 +61,7 @@ commonMain.dependencies {
 }
 ```
 
-### Independent Charts
+### Individual chart modules
 
 Use independent modules when you want only specific chart types and smaller dependency footprint.
 

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Charts</string>
+    <string name="app_name">HDCharts</string>
 </resources>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ kotlin {
     wasmJs {
         browser {
             commonWebpackConfig {
-                outputFileName = "Charts.js"
+                outputFileName = "HDCharts.js"
                 devServer = (devServer ?: KotlinWebpackConfig.DevServer()).copy()
             }
             binaries.executable()

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Charts</string>
+    <string name="app_name">HDCharts</string>
 
     <!-- Content descriptions -->
     <string name="github_url_content_description">GitHub repository</string>
@@ -48,7 +48,7 @@
     <string name="dark_mode_on">On</string>
     <string name="dark_mode_off">Off</string>
 
-    <!-- Charts title -->
+    <!-- HDCharts title -->
     <string name="pie_chart">Pie</string>
     <string name="line_chart">Line</string>
     <string name="bar_chart">Bar</string>
@@ -84,6 +84,6 @@
     <string name="style_status_default">Default</string>
     <string name="style_status_unused">Unused</string>
     <string name="style_status_count">(%1$d)</string>
-    <string translatable="false" name="github_url">https://github.com/dautovicharis/Charts</string>
+    <string translatable="false" name="github_url">https://github.com/HDCharts/charts</string>
 
 </resources>

--- a/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/MainScreen.kt
+++ b/app/src/commonMain/kotlin/io/github/dautovicharis/charts/app/MainScreen.kt
@@ -361,7 +361,7 @@ fun MainScreenContent(
         ChartGallery(
             menuState = menuState,
             onChartSelected = onChartSelected,
-            versionLabel = "Charts: ${BuildConfig.CHARTS_VERSION}",
+            versionLabel = "HDCharts: ${BuildConfig.CHARTS_VERSION}",
             modifier =
                 Modifier
                     .fillMaxWidth()

--- a/app/src/jvmMain/kotlin/Main.kt
+++ b/app/src/jvmMain/kotlin/Main.kt
@@ -11,7 +11,7 @@ fun main() =
     application {
         initKoin()
         Window(
-            title = "Charts Desktop Demo",
+            title = "HDCharts Desktop Demo",
             state = rememberWindowState(width = 600.dp, height = 800.dp),
             onCloseRequest = ::exitApplication,
         ) {

--- a/app/src/wasmJsMain/kotlin/WasmApp.kt
+++ b/app/src/wasmJsMain/kotlin/WasmApp.kt
@@ -5,7 +5,7 @@ import io.github.dautovicharis.charts.app.di.initKoin
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     initKoin()
-    ComposeViewport("Charts") {
+    ComposeViewport("HDCharts") {
         WebMainScreen()
     }
 }

--- a/app/src/wasmJsMain/resources/index.html
+++ b/app/src/wasmJsMain/resources/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Charts Demo</title>
+    <title>HDCharts Demo</title>
     <style>
         * {
             margin: 0;
@@ -16,7 +16,7 @@
             overflow: hidden;
             background: #fcfcfd;
         }
-        #Charts {
+        #HDCharts {
             width: 100%;
             height: 100%;
             background: inherit;
@@ -29,7 +29,7 @@
     </style>
 </head>
 <body>
-<div id="Charts"></div>
-<script type="module" src="Charts.js"></script>
+<div id="HDCharts"></div>
+<script type="module" src="HDCharts.js"></script>
 </body>
 </html>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -191,14 +191,14 @@ tasks.register("chartsTestAndroid") {
 }
 
 tasks.register("updateScreenshots") {
-    group = "Charts"
+    group = "HDCharts"
     description = "Updates Android screenshot test baselines (debug variant)"
     dependsOn(":androidApp:updateDebugScreenshotTest")
 }
 
 tasks.register("chartsCheck") {
-    group = "Charts"
-    description = "Build and tests for the charts project"
+    group = "HDCharts"
+    description = "Build and tests for the HDCharts project"
     dependsOn(getTasksByName("ktlintCheck", true))
     dependsOn("build")
     dependsOn("chartsTestJvm")
@@ -229,18 +229,18 @@ tasks.named("ktlintFormat").configure {
 
 tasks.register("publishChartsModules") {
     group = "publishing"
-    description = "Publishes all charts modules and BOM to the configured Maven repository"
+    description = "Publishes all HDCharts modules and BOM to the configured Maven repository"
     dependsOn(ChartsModules.publishable.map { "$it:publish" })
 }
 
 tasks.register("publishChartsModulesToMavenLocal") {
     group = "publishing"
-    description = "Publishes all charts modules and BOM to Maven Local"
+    description = "Publishes all HDCharts modules and BOM to Maven Local"
     dependsOn(ChartsModules.publishable.map { "$it:publishToMavenLocal" })
 }
 
 tasks.register<Sync>("generateWebDemo") {
-    group = "Charts"
+    group = "HDCharts"
     description = "Builds the Wasm web app and copies files to docs/static/demo/<target-version>"
 
     val docsVersionDir =
@@ -259,14 +259,14 @@ tasks.register<Sync>("generateWebDemo") {
 }
 
 tasks.register("generateApiDocs") {
-    group = "Charts"
+    group = "HDCharts"
     description = "Generate Dokka API reference to docs/static/api/<target-version>"
 
     dependsOn("charts:dokkaGenerate")
 }
 
 tasks.register("generateDocs") {
-    group = "Charts"
+    group = "HDCharts"
     description = "Generate Dokka API docs and Wasm web demo to docs/static/"
 
     dependsOn("generateApiDocs")
@@ -278,27 +278,27 @@ tasks.register("generateDocs") {
 }
 
 tasks.register("listDocsGifScenarios") {
-    group = "Charts"
+    group = "HDCharts"
     description = "Lists available docs GIF scenarios discovered via @RecordGif in :androidApp"
     dependsOn(":androidApp:listGifScenarios")
 }
 
 tasks.register("recordDocsGif") {
-    group = "Charts"
+    group = "HDCharts"
     description =
         "Records one docs GIF scenario to <gifContentRoot>/<gifDocsVersion>/wiki/assets (set -PgifScenario=<name>, defaults to first)"
     dependsOn(":androidApp:recordGifDebug")
 }
 
 tasks.register("recordDocsGifs") {
-    group = "Charts"
+    group = "HDCharts"
     description =
         "Records all docs GIF scenarios to <gifContentRoot>/<gifDocsVersion>/wiki/assets (default version: snapshot)"
     dependsOn(":androidApp:recordGifsDebug")
 }
 
 tasks.register("validateDocsGifBaselines") {
-    group = "Charts"
+    group = "HDCharts"
     description = "Validates Android docs GIF output against gif-baselines"
     dependsOn(":androidApp:validateGifBaselines")
 }

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -29,7 +29,7 @@ object Config {
     const val DEMO_VERSION_NAME = "1.0.0"
     const val DEMO_VERSION_CODE = 8
 
-    // Charts library
+    // HDCharts library
     const val CHARTS_NAMESPACE = "$GROUP_ID.$ARTIFACT_ID"
     const val CHARTS_CORE_NAMESPACE = "$GROUP_ID.charts.core"
     const val CHARTS_LINE_NAMESPACE = "$GROUP_ID.charts.line"

--- a/charts-bar/build.gradle.kts
+++ b/charts-bar/build.gradle.kts
@@ -89,7 +89,7 @@ mavenPublishing {
         ChartsPublishing.configurePom(
             pom = this,
             moduleName = "Bar Chart",
-            moduleDescription = "Bar chart module for Charts.",
+            moduleDescription = "Bar chart module for HDCharts.",
         )
     }
 }

--- a/charts-bom/build.gradle.kts
+++ b/charts-bom/build.gradle.kts
@@ -34,8 +34,8 @@ mavenPublishing {
     pom {
         ChartsPublishing.configurePom(
             pom = this,
-            moduleName = "Charts BOM",
-            moduleDescription = "Bill of Materials (BOM) for aligning Charts module versions.",
+            moduleName = "HDCharts BOM",
+            moduleDescription = "Bill of Materials (BOM) for aligning HDCharts module versions.",
         )
     }
 }

--- a/charts-core/build.gradle.kts
+++ b/charts-core/build.gradle.kts
@@ -90,8 +90,8 @@ mavenPublishing {
     pom {
         ChartsPublishing.configurePom(
             pom = this,
-            moduleName = "Charts Core",
-            moduleDescription = "Core components for Charts.",
+            moduleName = "HDCharts Core",
+            moduleDescription = "Core components for HDCharts.",
         )
     }
 }

--- a/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/ChartsPreviews.kt
+++ b/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/ChartsPreviews.kt
@@ -41,7 +41,7 @@ fun ChartsPreviewTheme(content: @Composable () -> Unit) {
 private fun ChartsCoreContainerPreview() {
     ChartsPreviewTheme {
         Chart(chartViewsStyle = ChartViewDefaults.style()) {
-            Text("Charts Core Container")
+            Text("HDCharts Core Container")
         }
     }
 }

--- a/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/InternalChartsApi.kt
+++ b/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/InternalChartsApi.kt
@@ -6,7 +6,7 @@ package io.github.dautovicharis.charts.internal
  * These APIs are public for module interoperability but are not stable for direct consumer usage.
  */
 @RequiresOptIn(
-    message = "Internal HDCharts API. This may change without notice.",
+    message = "Internal Charts API. This may change without notice.",
     level = RequiresOptIn.Level.ERROR,
 )
 @Target(

--- a/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/InternalChartsApi.kt
+++ b/charts-core/src/commonMain/kotlin/io/github/dautovicharis/charts/internal/InternalChartsApi.kt
@@ -6,7 +6,7 @@ package io.github.dautovicharis.charts.internal
  * These APIs are public for module interoperability but are not stable for direct consumer usage.
  */
 @RequiresOptIn(
-    message = "Internal Charts API. This may change without notice.",
+    message = "Internal HDCharts API. This may change without notice.",
     level = RequiresOptIn.Level.ERROR,
 )
 @Target(

--- a/charts-histogram/build.gradle.kts
+++ b/charts-histogram/build.gradle.kts
@@ -90,7 +90,7 @@ mavenPublishing {
         ChartsPublishing.configurePom(
             pom = this,
             moduleName = "Histogram Chart",
-            moduleDescription = "Histogram chart module for Charts.",
+            moduleDescription = "Histogram chart module for HDCharts.",
         )
     }
 }

--- a/charts-line/build.gradle.kts
+++ b/charts-line/build.gradle.kts
@@ -89,7 +89,7 @@ mavenPublishing {
         ChartsPublishing.configurePom(
             pom = this,
             moduleName = "Line Chart",
-            moduleDescription = "Line chart module for Charts.",
+            moduleDescription = "Line chart module for HDCharts.",
         )
     }
 }

--- a/charts-pie/build.gradle.kts
+++ b/charts-pie/build.gradle.kts
@@ -89,7 +89,7 @@ mavenPublishing {
         ChartsPublishing.configurePom(
             pom = this,
             moduleName = "Pie Chart",
-            moduleDescription = "Pie chart module for Charts.",
+            moduleDescription = "Pie chart module for HDCharts.",
         )
     }
 }

--- a/charts-radar/build.gradle.kts
+++ b/charts-radar/build.gradle.kts
@@ -89,7 +89,7 @@ mavenPublishing {
         ChartsPublishing.configurePom(
             pom = this,
             moduleName = "Radar Chart",
-            moduleDescription = "Radar chart module for Charts.",
+            moduleDescription = "Radar chart module for HDCharts.",
         )
     }
 }

--- a/charts-stacked-area/build.gradle.kts
+++ b/charts-stacked-area/build.gradle.kts
@@ -89,7 +89,7 @@ mavenPublishing {
         ChartsPublishing.configurePom(
             pom = this,
             moduleName = "Stacked Area Chart",
-            moduleDescription = "Stacked area chart module for Charts.",
+            moduleDescription = "Stacked area chart module for HDCharts.",
         )
     }
 }

--- a/charts-stacked-bar/build.gradle.kts
+++ b/charts-stacked-bar/build.gradle.kts
@@ -89,7 +89,7 @@ mavenPublishing {
         ChartsPublishing.configurePom(
             pom = this,
             moduleName = "Stacked Bar Chart",
-            moduleDescription = "Stacked bar chart module for Charts.",
+            moduleDescription = "Stacked bar chart module for HDCharts.",
         )
     }
 }

--- a/charts/build.gradle.kts
+++ b/charts/build.gradle.kts
@@ -160,8 +160,8 @@ mavenPublishing {
     pom {
         ChartsPublishing.configurePom(
             pom = this,
-            moduleName = "Charts",
-            moduleDescription = "Charts.",
+            moduleName = "HDCharts",
+            moduleDescription = "HDCharts library.",
         )
     }
 }

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -3,8 +3,8 @@
 This directory contains release workflow diagrams split by flow.
 
 - [High-Level Map](./high-level-map.md)
-- [Charts Release](./charts-release.md)
-- [Charts Snapshot](./charts-snapshot.md)
+- [HDCharts Release](./charts-release.md)
+- [HDCharts Snapshot](./charts-snapshot.md)
 - [Versioning](./versioning.md)
 - [Release Checklist](./release-checklist.md)
 - [Workflow Security](./workflow-security.md)

--- a/docs/release/charts-release.md
+++ b/docs/release/charts-release.md
@@ -1,4 +1,4 @@
-# Charts Release
+# HDCharts Release
 
 Workflow: `charts/.github/workflows/release.yml`
 

--- a/docs/release/charts-snapshot.md
+++ b/docs/release/charts-snapshot.md
@@ -1,4 +1,4 @@
-# Charts Snapshot
+# HDCharts Snapshot
 
 Workflow: `charts/.github/workflows/snapshot-release.yml`
 

--- a/hdcharts-logo.svg
+++ b/hdcharts-logo.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="416" height="128" viewBox="0 16 416 128" role="img" aria-labelledby="title desc">
+  <title id="title">HDCharts</title>
+  <desc id="desc">HDCharts logo that adapts to light and dark browser themes.</desc>
+
+  <style>
+    .wordmark-primary { fill: #1F2933; }
+    .wordmark-brand { fill: #39777A; }
+
+    @media (prefers-color-scheme: dark) {
+      .wordmark-primary { fill: #F7F9F8; }
+      .wordmark-brand { fill: #9AD7D3; }
+    }
+  </style>
+
+  <g transform="translate(0 16) scale(0.8)">
+    <rect width="160" height="160" rx="38" fill="#39777A"/>
+    <path d="M34 65V45c0-9.4 7.6-17 17-17h45M126 98v17c0 9.4-7.6 17-17 17H92" fill="none" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round"/>
+    <path d="M29 105c13-8 22-27 35-24 12 3 17 14 29 8 13-6 24-27 38-43" fill="none" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round" stroke-linejoin="round"/>
+    <g fill="#C7892F" opacity="0.86">
+      <circle cx="29" cy="105" r="4.5"/>
+      <circle cx="64" cy="81" r="4.5"/>
+      <circle cx="93" cy="89" r="4.5"/>
+      <circle cx="131" cy="46" r="4.5"/>
+    </g>
+  </g>
+
+  <path class="wordmark-primary" d="M495 0V286H229V0H77V698H229V420H495V698H647V0Z" transform="translate(154 101) scale(0.062 -0.062)"/>
+  <path class="wordmark-primary" d="M77 0V698H340Q433 698 502 659Q571 620 609 542.5Q647 465 647 349Q647 233 609 155.5Q571 78 502 39Q433 0 340 0ZM229 135H340Q385 135 418 152Q451 169 468.5 204.5Q486 240 486 295V403Q486 459 468.5 494Q451 529 418 546Q385 563 340 563H229Z" transform="translate(196.388 101) scale(0.062 -0.062)"/>
+  <path class="wordmark-brand" d="M359 -12Q265 -12 195.5 28Q126 68 88 147Q50 226 50 344Q50 462 88 543.5Q126 625 195.5 667.5Q265 710 359 710Q455 710 518.5 670Q582 630 620 546L489 478Q476 522 445.5 548.5Q415 575 359 575Q292 575 251.5 531.5Q211 488 211 405V293Q211 211 251.5 167Q292 123 359 123Q415 123 448.5 153.5Q482 184 498 227L622 155Q583 76 519 32Q455 -12 359 -12Z" transform="translate(237.102 101) scale(0.062 -0.062)"/>
+  <path class="wordmark-brand" d="M69 0V740H217V436H223Q237 477 272 507Q307 537 369 537Q449 537 491 482.5Q533 428 533 329V0H385V317Q385 367 369 392Q353 417 312 417Q288 417 266.5 408.5Q245 400 231 383Q217 366 217 340V0Z" transform="translate(274.964 101) scale(0.062 -0.062)"/>
+  <path class="wordmark-brand" d="M539 0H457Q430 0 406.5 13.5Q383 27 369 53.5Q355 80 355 117V130L387 92H351Q339 41 298 14.5Q257 -12 197 -12Q118 -12 76 30.5Q34 73 34 141Q34 197 61.5 233Q89 269 139.5 287Q190 305 259 305H342V338Q342 376 322 398.5Q302 421 255 421Q211 421 185 402Q159 383 142 359L54 437Q86 484 135 510.5Q184 537 266 537Q377 537 433.5 487.5Q490 438 490 345V115H539ZM342 221H270Q227 221 205 206Q183 191 183 162V147Q183 119 201 105Q219 91 252 91Q277 91 297 98Q317 105 329.5 120Q342 135 342 159Z" transform="translate(309.416 101) scale(0.062 -0.062)"/>
+  <path class="wordmark-brand" d="M217 0H69V525H217V411H222Q228 440 244 466Q260 492 287.5 508.5Q315 525 356 525H382V387H345Q302 387 273.5 379.5Q245 372 231 355Q217 338 217 307Z" transform="translate(342.194 101) scale(0.062 -0.062)"/>
+  <path class="wordmark-brand" d="M341 0H253Q177 0 137 39Q97 78 97 153V410H23V525H60Q90 525 101 539.5Q112 554 112 581V667H245V525H349V410H245V115H341Z" transform="translate(364.742 101) scale(0.062 -0.062)"/>
+  <path class="wordmark-brand" d="M247 -12Q171 -12 119 12.5Q67 37 26 82L113 170Q141 139 175 121Q209 103 252 103Q296 103 313 116.5Q330 130 330 153Q330 173 317.5 183Q305 193 277 197L220 204Q161 212 121.5 232Q82 252 62.5 285.5Q43 319 43 366Q43 442 98 489.5Q153 537 247 537Q302 537 340 527.5Q378 518 406.5 499.5Q435 481 461 455L376 368Q351 393 319.5 407.5Q288 422 255 422Q218 422 201.5 410Q185 398 185 378Q185 357 196.5 345.5Q208 334 240 329L299 321Q385 310 428.5 270.5Q472 231 472 163Q472 113 444 73Q416 33 365.5 10.5Q315 -12 247 -12Z" transform="translate(385.988 101) scale(0.062 -0.062)"/>
+</svg>

--- a/iosApp/Configuration/Config.xcconfig
+++ b/iosApp/Configuration/Config.xcconfig
@@ -1,3 +1,3 @@
 TEAM_ID=
 BUNDLE_ID=io.github.dautovicharis.charts.app
-APP_NAME=Charts
+APP_NAME=HDCharts

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
-		7555FF7B242A565900829871 /* Charts.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Charts.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7555FF7B242A565900829871 /* HDCharts.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HDCharts.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -62,7 +62,7 @@
 		7555FF7C242A565900829871 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				7555FF7B242A565900829871 /* Charts.app */,
+				7555FF7B242A565900829871 /* HDCharts.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -107,7 +107,7 @@
 			packageProductDependencies = (
 			);
 			productName = iosApp;
-			productReference = 7555FF7B242A565900829871 /* Charts.app */;
+			productReference = 7555FF7B242A565900829871 /* HDCharts.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "ChartsProject"
+rootProject.name = "HDChartsProject"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 val chartsDependencyMode =

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "HDChartsProject"
+rootProject.name = "ChartsProject"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 val chartsDependencyMode =


### PR DESCRIPTION
## Summary

- Rebrand user-facing app, README, release, workflow, POM metadata, and project labels as HDCharts.
- Update the Wasm demo filename and matching HTML entry point.
- Update the iOS product reference and GitHub attachment URL.
- Preserve Maven coordinates, artifact IDs, package namespaces, and bundle identifier.

## Validation

- YAML parsing for all GitHub Actions/workflow files
- git diff --check
- ./gradlew help --no-daemon --console=plain
- xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -showBuildSettings