### PR TITLE
ci: skip heavy jobs for API baseline-only updates

### DIFF
--- a/scripts/ci-has-code-changes.sh
+++ b/scripts/ci-has-code-changes.sh
@@ -8,7 +8,7 @@ is_code_change() {
   while IFS= read -r changed_file; do
     [[ -n "$changed_file" ]] || continue
     case "$changed_file" in
-      docs/*|release-notes/*|gif-baselines/*|scripts/*|.editorconfig|*.md|LICENSE|LICENSE.*|readme-assets/*) ;;
+      docs/*|release-notes/*|gif-baselines/*|scripts/*|.github/api-compatibility-baseline.txt|.editorconfig|*.md|LICENSE|LICENSE.*|readme-assets/*) ;;
       *)
         echo "true"
         return
@@ -84,6 +84,11 @@ run_self_test() {
 
   result="$(is_code_change $'README.md\ngif-baselines/bar.png')"
   if ! assert_equal "false" "$result" "gif baseline change"; then
+    failures=$((failures + 1))
+  fi
+
+  result="$(is_code_change $'README.md\n.github/api-compatibility-baseline.txt')"
+  if ! assert_equal "false" "$result" "api compatibility baseline change"; then
     failures=$((failures + 1))
   fi
 


### PR DESCRIPTION
## Summary
- Exclude `.github/api-compatibility-baseline.txt` from the code-change detection in `scripts/ci-has-code-changes.sh`.
- Baseline-only PRs (e.g. #529) no longer trigger the assemble/compile/lint/test jobs.
- Added a self-test case asserting a baseline-only change is not treated as a code change.